### PR TITLE
Adding the possibility, to not show a flash message.

### DIFF
--- a/flaskext/login.py
+++ b/flaskext/login.py
@@ -374,7 +374,7 @@ class LoginManager(object):
         if self.token_callback:
             data = current_user.get_auth_token()
         else:
-            data = encode_cookie(session["user_id"])
+            data = encode_cookie(str(session["user_id"]))
         expires = datetime.now() + duration
         # actually set it
         response.set_cookie(cookie_name, data, expires=expires, domain=domain)


### PR DESCRIPTION
I had to override the unauthorized_handler, just because I wanted no flash message. I would love to see this in flask-login.

login_manager.login_message = None

Wouldn't show a flash anymore. :)
