### PR TITLE
Fixed a weird bug

### DIFF
--- a/flaskext/login.py
+++ b/flaskext/login.py
@@ -358,7 +358,7 @@ class LoginManager(object):
     
     def _update_remember_cookie(self, response):
         operation = session.pop("remember", None)
-        if operation == "set":
+        if operation == "set" and "user_id" in session:
             self._set_cookie(response)
         elif operation == "clear":
             self._clear_cookie(response)


### PR DESCRIPTION
Fixed a bug that happens when the 'user_id' is not present in the session and the `logout_user()` is called. The action before the bug causes a KeyError.

Much thanks to atdt from #python on freenode for identifying and fixing the bug. Im just doing the leg work.
