### PR TITLE
Lazy strings don't survive in the session across requests

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -400,7 +400,7 @@ class LoginManager(object):
 
 
 #: A proxy for the current user.
-current_user = LocalProxy(lambda: getattr(_request_ctx_stack.top, 'user'))
+current_user = LocalProxy(lambda: getattr(_request_ctx_stack.top, 'user', None))
 
 def _user_context_processor():
     return dict(current_user=_get_user())


### PR DESCRIPTION
Hi,

It appears that lazy strings (such as ones created by speaklater and lazy_gettext) do not survive when stored in the session. This forces them to be evaluated before being stored there
