### PR TITLE
use UTC for cookie expire instead of local time

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -388,7 +388,7 @@ class LoginManager(object):
             data = current_user.get_auth_token()
         else:
             data = encode_cookie(str(session["user_id"]))
-        expires = datetime.now() + duration
+        expires = datetime.utcnow() + duration
         # actually set it
         response.set_cookie(cookie_name, data, expires=expires, domain=domain)
 


### PR DESCRIPTION
This isn't directly documented in Flask, 
but in Django they make a notice of it[1]( https://docs.djangoproject.com/en/dev/ref/request-response/#django.http.HttpResponse.set_cookie). 
The hint in Werkzeug documentation is when 
they mention a UNIX timestamp. 
