### PR TITLE
Added message categories for flash messages

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -143,6 +143,10 @@ customize the message, set `LoginManager.login_message`::
 
     login_manager.login_message = u"Bonvolu ensaluti por uzi tio paĝo."
 
+To customize the message category, set `LoginManager.login_message_category`::
+
+    login_manager.login_message_category = "info"
+
 When the log in view is redirected to, it will have a `next` variable in the
 query string, which is the page that the user was trying to access.
 
@@ -229,12 +233,14 @@ one's password should always require a password re-entry regardless.)
 in, will also ensure that their login is fresh. If not, it will send them to
 a page where they can re-enter their credentials. You can customize its
 behavior in the same ways as you can customize `login_required`, by setting
-`LoginManager.refresh_view` and `~LoginManager.needs_refresh_message`::
+`LoginManager.refresh_view`, `~LoginManager.needs_refresh_message`, and
+`~LoginManager.needs_refresh_message_category`::
 
     login_manager.refresh_view = "accounts.reauthenticate"
     login_manager.needs_refresh_message = (
         u"To protect your account, please reauthenticate to access this page."
     )
+    login_manager.needs_refresh_message_category = "info"
 
 Or by providing your own callback to handle refreshing::
 

--- a/flask_login.py
+++ b/flask_login.py
@@ -145,9 +145,15 @@ COOKIE_DURATION = timedelta(days=365)
 #: The default flash message to display when users need to log in.
 LOGIN_MESSAGE = u"Please log in to access this page."
 
+#: The default flash message category to display when users need to log in.
+LOGIN_MESSAGE_CATEGORY = "message"
+
 #: The default flash message to display when users need to reauthenticate.
 REFRESH_MESSAGE = u"Please reauthenticate to access this page."
 
+#: The default flash message category to display when users need to
+#: reauthenticate.
+REFRESH_MESSAGE_CATEGORY = "message"
 
 class LoginManager(object):
     """
@@ -166,12 +172,18 @@ class LoginManager(object):
         self.login_view = None
         #: The message to flash when a user is redirected to the login page.
         self.login_message = LOGIN_MESSAGE
+        #: The message category to flash when a user is redirected to the login
+        #: page.
+        self.login_message_category = LOGIN_MESSAGE_CATEGORY
         #: The name of the view to redirect to when the user needs to
         #: reauthenticate.
         self.refresh_view = None
         #: The message to flash when a user is redirected to the "needs
         #: refresh" page.
         self.needs_refresh_message = REFRESH_MESSAGE
+        #: The message category to flash when a user is redirected to the
+        #: "needs refresh" page.
+        self.needs_refresh_message_category = REFRESH_MESSAGE_CATEGORY
         #: The mode to use session protection in. This can be either
         #: ``"basic"`` (the default) or ``"strong"``, or `None` to disable it.
         self.session_protection = "basic"
@@ -261,7 +273,7 @@ class LoginManager(object):
         if not self.login_view:
             abort(401)
         if self.login_message:
-            flash(self.login_message)
+            flash(self.login_message, category=self.login_message_category)
         return redirect(login_url(self.login_view, request.url))
 
     def needs_refresh_handler(self, callback):
@@ -298,7 +310,7 @@ class LoginManager(object):
             return self.needs_refresh_callback()
         if not self.refresh_view:
             abort(403)
-        flash(self.needs_refresh_message)
+        flash(self.needs_refresh_message, category=self.needs_refresh_message_category)
         return redirect(login_url(self.refresh_view, request.url))
 
     def _load_user(self):
@@ -527,9 +539,9 @@ class LoginRequiredMixin(object):
     """
     @login_required
     def dispatch_request(self, *args, **kwargs):
-        return super(LoginRequiredMixin, self).dispatch_request(*args, **kwargs) 
+        return super(LoginRequiredMixin, self).dispatch_request(*args, **kwargs)
 
-    
+
 class UserMixin(object):
     """
     This provides default implementations for the methods that Flask-Login


### PR DESCRIPTION
It would be nice to be able to change the flash message categories for the login and refresh messages. This change leaves the default use of the flash "message" category for both messages, but allows for either to be changed.
