### PR TITLE
Fix docstrings so that `next` doesn't point to python doc

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -147,7 +147,7 @@ To customize the message category, set `LoginManager.login_message_category`::
 
     login_manager.login_message_category = "info"
 
-When the log in view is redirected to, it will have a `next` variable in the
+When the log in view is redirected to, it will have a ``next`` variable in the
 query string, which is the page that the user was trying to access.
 
 If you would like to customize the process further, decorate a function with

--- a/flask_login.py
+++ b/flask_login.py
@@ -258,7 +258,7 @@ class LoginManager(object):
 
         - Flash `login_message` to the user.
         - Redirect the user to `login_view`. (The page they were attempting
-          to access will be passed in the `next` query string variable, so
+          to access will be passed in the ``next`` query string variable, so
           you can redirect there if present instead of the homepage.)
 
         If `login_view` is not defined, then it will simply raise a 401
@@ -296,7 +296,7 @@ class LoginManager(object):
 
         - Flash `needs_refresh_message` to the user.
         - Redirect the user to `refresh_view`. (The page they were attempting
-          to access will be passed in the `next` query string variable, so
+          to access will be passed in the ``next`` query string variable, so
           you can redirect there if present instead of the homepage.)
 
         If `refresh_view` is not defined, then it will simply raise a 403


### PR DESCRIPTION
Currently, Sphinx automatically links word `next` (with single backticks) to the [python doc](http://docs.python.org/library/functions.html#next).

This pull request uses double-backticks to fix this, so that it is displayed as a normal variable. This is consistent with the docstring [here](https://github.com/maxcountryman/flask-login/blob/master/flask_login.py#L94).

Happy to make any changes you suggest!
