### PR TITLE
Update to session_id identified to work with Flask 0.10

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -133,7 +133,7 @@ def _create_identifier():
                               request.headers.get("User-Agent")), 'utf8', errors='replace')
     hsh = md5()
     hsh.update(base.encode("utf8"))
-    return hsh.digest()
+    return hsh.hexdigest()
 
 
 #: The default name of the "remember me" cookie (``remember_token``)


### PR DESCRIPTION
The current dev version of flask enforces unicode restrictions on the session id.  This causes the identifier data originally created using digest() in binary to throw errors, by changing to hexdigest() this problem is easily avoided for future Flask releases.
