### PR TITLE
Fixing python error when connecting with an old cookie

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -371,6 +371,8 @@ class LoginManager(object):
                 ctx.user = user
 
     def _load_from_cookie(self, cookie):
+        user_id = None #initialize user_id to None to prevent UnboundLocalError
+        
         if self.token_callback:
             user = self.token_callback(cookie)
             if user is not None:


### PR DESCRIPTION
here's the callstack:

  File "/app/.heroku/src/flask-login/flask_login.py", line 337, in _load_user 
May 25 14:33:33 mightyspring app/web.1:      self._load_from_cookie(request.cookies[cookie_name]) 
May 25 14:33:33 mightyspring app/web.1:    File "/app/.heroku/src/flask-login/flask_login.py", line 381, in _load_from_cookie 
May 25 14:33:33 mightyspring app/web.1:      if user_id is not None: 
May 25 14:33:33 mightyspring app/web.1:  UnboundLocalError: local variable 'user_id' referenced before assignment 
