### PR TITLE
Fixed test case

### DIFF
--- a/test_login.py
+++ b/test_login.py
@@ -121,7 +121,7 @@ class LoginTestCase(unittest.TestCase):
             return self.login_manager.unauthorized()
 
         @self.app.route('/login-notch')
-        def login():
+        def login_notch():
             return unicode(login_user(notch))
 
         @self.app.route('/login-notch-remember')
@@ -279,7 +279,7 @@ class LoginTestCase(unittest.TestCase):
             result = c.get('/secret')
             self.assertEqual(result.status_code, 302)
             self.assertEqual(result.location,
-                             'http://localhost/login-notch?next=%2Fsecret')
+                             'http://localhost/login?next=%2Fsecret')
 
     #
     # Session Persistence/Freshness


### PR DESCRIPTION
The test app had the '/login-notch' URL using a function named "login", which caused problems later on for tests that defined their own "login" function, although not in a way that caused the test to fail. In one case, the test SHOULD have failed because the assertion had the incorrect value: the test app is now correct and the invalid assertion is now valid.
