### PR TITLE
If available, use X-Forwarded-For header instead of request.remote_addr for the session protectin id

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -693,8 +693,12 @@ def _cookie_digest(payload, key=None):
     return hmac.new(key, payload.encode('utf-8'), sha1).hexdigest()
 
 
+def _get_remote_addr():
+    return request.headers.get('X-Forwarded-For', request.remote_addr)
+
+
 def _create_identifier():
-    base = '{0}|{1}'.format(request.remote_addr,
+    base = '{0}|{1}'.format(_get_remote_addr(),
                             request.headers.get('User-Agent'))
     if str is bytes:
         base = unicode(base, 'utf-8', errors='replace')

--- a/test_login.py
+++ b/test_login.py
@@ -538,6 +538,16 @@ class LoginTestCase(unittest.TestCase):
                 c.get('/username', headers=[('User-Agent', 'different')])
                 listener.assert_heard_one(self.app)
 
+    def test_session_protection_strong_fires_signal_x_forwarded_for(self):
+        self.app.config['SESSION_PROTECTION'] = 'strong'
+
+        with self.app.test_client() as c:
+            c.get('/login-notch-remember',
+                  headers=[('X-Forwarded-For', '10.1.1.1')])
+            with listen_to(session_protected) as listener:
+                c.get('/username', headers=[('X-Forwarded-For', '10.1.1.2')])
+                listener.assert_heard_one(self.app)
+
     #
     # Custom Token Loader
     #


### PR DESCRIPTION
This fixes #101, added a test for it. Let me know if you are willing to merge this or if you disagree w/the change. Thanks!
