### PR TITLE
Fix SECRET_KEY encode in Python 2

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -534,12 +534,7 @@ def make_secure_token(*args, **options):
     :type \*\*options: kwargs
     '''
     key = options.get('key')
-
-    if key is None:
-        key = current_app.config['SECRET_KEY']
-
-    if hasattr(key, 'encode'):  # pragma: no cover
-        key = key.encode('utf-8')  # ensure bytes
+    key = _secret_key(key)
 
     l = [s if isinstance(s, bytes) else s.encode('utf-8') for s in args]
 
@@ -699,11 +694,7 @@ def _get_user():
 
 
 def _cookie_digest(payload, key=None):
-    if key is None:
-        key = current_app.config['SECRET_KEY']
-
-    if hasattr(key, 'encode'):
-        key = key.encode('utf-8')  # ensure bytes
+    key = _secret_key(key)
 
     return hmac.new(key, payload.encode('utf-8'), sha1).hexdigest()
 
@@ -724,6 +715,16 @@ def _create_identifier():
 
 def _user_context_processor():
     return dict(current_user=_get_user())
+
+
+def _secret_key(key=None):
+    if key is None:
+        key = current_app.config['SECRET_KEY']
+
+    if isinstance(key, unicode):  # pragma: no cover
+        key = key.encode('latin1')  # ensure bytes
+
+    return key
 
 
 # Signals

--- a/test_login.py
+++ b/test_login.py
@@ -20,7 +20,7 @@ from flask.ext.login import (LoginManager, UserMixin, AnonymousUserMixin,
                              login_required, session_protected,
                              fresh_login_required, confirm_login,
                              encode_cookie, decode_cookie,
-                             _user_context_processor)
+                             _secret_key, _user_context_processor)
 
 
 # be compatible with py3k
@@ -738,6 +738,24 @@ class CookieEncodingTestCase(unittest.TestCase):
             self.assertEqual(u'1', decode_cookie(COOKIE))
             self.assertIsNone(decode_cookie(u'Foo|BAD_BASH'))
             self.assertIsNone(decode_cookie(u'no bar'))
+
+
+class SecretKeyTestCase(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+
+    def test_bytes(self):
+        self.app.config['SECRET_KEY'] = b'\x9e\x8f\x14'
+        with self.app.test_request_context():
+            self.assertEqual(_secret_key(), b'\x9e\x8f\x14')
+
+    def test_native(self):
+        self.app.config['SECRET_KEY'] = '\x9e\x8f\x14'
+        with self.app.test_request_context():
+            self.assertEqual(_secret_key(), b'\x9e\x8f\x14')
+
+    def test_default(self):
+        self.assertEqual(_secret_key('\x9e\x8f\x14'), b'\x9e\x8f\x14')
 
 
 class ImplicitIdUser(UserMixin):


### PR DESCRIPTION
fix #106
