### PR TITLE
always remove Basic from Authorization header in example code

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -174,8 +174,7 @@ a header value instead of a user id. For example::
 
     @login_manager.header_loader
     def load_user_from_header(header_val):
-        if header_val.startswith('Basic '):                                             
-            header_val = header_val.replace('Basic ', '', 1)                                
+        header_val = header_val.replace('Basic ', '', 1)                                
         try:                                                                        
             header_val = base64.b64decode(header_val)                                       
         except TypeError:                                                     
@@ -211,8 +210,7 @@ using the `Authorization` header::
         # next, try to login using Basic Auth
         api_key = request.headers.get('Authorization')
         if api_key:
-            if api_key.startswith('Basic '):                                             
-                api_key= api_key.replace('Basic ', '', 1)                                
+            api_key = api_key.replace('Basic ', '', 1)                                
             try:                                                                        
                 api_key = base64.b64decode(api_key)                                       
             except TypeError:                                                     


### PR DESCRIPTION
A simple change to the `header_loader` and `request_loader` example code.

No need to check if the header starts with `Basic` before replacing it.
