### PR TITLE
implement "NO_SESSION" option to avoid saving session cookies

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -369,7 +369,7 @@ class LoginManager(object):
     def _session_protection(self):
 
         if current_app.config.get('NO_SESSION', NO_SESSION):
-            return True
+            return False
 
         sess = session._get_current_object()
         ident = _create_identifier()


### PR DESCRIPTION
I'm developing a REST API using flask-login and flask-principal through flask-security,
for a REST API authentication (for example using the request_loader) it would be better not setting any cookie, since they are not needed.
