### PR TITLE
add set_login_view helper function and tests for per-blueprint login views

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -816,10 +816,20 @@ def set_login_view(login_view, blueprint=None):
         Defaults to ``None``.
     :type blueprint: object
     '''
-    if blueprint is not None or len(current_app.login_manager.blueprint_login_views) != 0:
-        current_app.login_manager.blueprint_login_views[blueprint.name] = login_view
-        if current_app.login_manager.login_view is not None and None not in current_app.login_manager.blueprint_login_views:
-            current_app.login_manager.blueprint_login_views[None] = current_app.login_manager.login_view
+
+    num_login_views = len(current_app.login_manager.blueprint_login_views)
+    if blueprint is not None or num_login_views != 0:
+
+        (current_app.login_manager
+            .blueprint_login_views[blueprint.name]) = login_view
+
+        if (current_app.login_manager.login_view is not None and
+                None not in current_app.login_manager.blueprint_login_views):
+
+            (current_app.login_manager
+                .blueprint_login_views[None]) = (current_app.login_manager
+                                                 .login_view)
+
         current_app.login_manager.login_view = None
     else:
         current_app.login_manager.login_view = login_view

--- a/test_login.py
+++ b/test_login.py
@@ -468,19 +468,21 @@ class LoginTestCase(unittest.TestCase):
 
                 result = c.get('/protected')
                 self.assertEqual(result.status_code, 302)
-                self.assertEqual(result.location,
-                             'http://localhost/app_login?next=%2Fprotected')
+                expected = ('http://localhost/'
+                            'app_login?next=%2Fprotected')
+                self.assertEqual(result.location, expected)
 
                 result = c.get('/first/protected')
                 self.assertEqual(result.status_code, 302)
-                self.assertEqual(result.location,
-                             'http://localhost/first_login?next=%2Ffirst%2Fprotected')
+                expected = ('http://localhost/'
+                            'first_login?next=%2Ffirst%2Fprotected')
+                self.assertEqual(result.location, expected)
 
                 result = c.get('/second/protected')
                 self.assertEqual(result.status_code, 302)
-                self.assertEqual(result.location,
-                             'http://localhost/second_login?next=%2Fsecond%2Fprotected')
-
+                expected = ('http://localhost/'
+                            'second_login?next=%2Fsecond%2Fprotected')
+                self.assertEqual(result.location, expected)
 
     def test_set_login_view_without_blueprints(self):
         with self.app.app_context():
@@ -500,8 +502,8 @@ class LoginTestCase(unittest.TestCase):
 
                 result = c.get('/protected')
                 self.assertEqual(result.status_code, 302)
-                self.assertEqual(result.location,
-                             'http://localhost/app_login?next=%2Fprotected')
+                expected = 'http://localhost/app_login?next=%2Fprotected'
+                self.assertEqual(result.location, expected)
 
     #
     # Session Persistence/Freshness


### PR DESCRIPTION
This is for my comment on #164
