### PR TITLE
Add login_required to a blueprint

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -776,6 +776,26 @@ def login_required(func):
     return decorated_view
 
 
+def blueprint_login_required():
+    '''
+    If you set a before_request with this, it will ensure that the current
+    user is logged in and authenticated before calling any view from this
+    blueprint. (If they are not, it calls the
+    :attr:`LoginManager.unauthorized` callback.) For example::
+
+        secure_blueprint = Blueprint('secure_blueprint', __name__)
+        secure_blueprint.before_request(blueprint_login_required)
+
+    It can be convenient to globally turn off authentication when unit
+    testing. To enable this, if either of the application
+    configuration variables `LOGIN_DISABLED` or `TESTING` is set to
+    `True`, this decorator will be ignored.
+    '''
+    if (not current_app.login_manager._login_disabled and
+            not current_user.is_authenticated()):
+        return current_app.login_manager.unauthorized()
+
+
 def fresh_login_required(func):
     '''
     If you decorate a view with this, it will ensure that the current user's

--- a/test_login.py
+++ b/test_login.py
@@ -31,7 +31,7 @@ from flask.ext.login import (LoginManager, UserMixin, AnonymousUserMixin,
                              fresh_login_required, confirm_login,
                              encode_cookie, decode_cookie, set_login_view,
                              _secret_key, _user_context_processor,
-                             user_accessed)
+                             user_accessed, blueprint_login_required)
 
 
 # be compatible with py3k
@@ -512,6 +512,52 @@ class LoginTestCase(unittest.TestCase):
                 result = c.get('/protected')
                 self.assertEqual(result.status_code, 302)
                 expected = 'http://localhost/app_login?next=%2Fprotected'
+                self.assertEqual(result.location, expected)
+
+    def test_unauthorized_uses_blueprint_before_request(self):
+        with self.app.app_context():
+
+            first = Blueprint('first', 'first')
+            second = Blueprint('second', 'second')
+            second.before_request(blueprint_login_required)
+
+            @self.app.route('/app_login')
+            def app_login():
+                return 'Login Form Goes Here!'
+
+            @first.route('/unsecure')
+            def first_unsecure():
+                return u'Always Granted'
+
+            @first.route('/protected')
+            @login_required
+            def first_protected():
+                return u'Access Granted'
+
+            @second.route('/protected')
+            def second_protected():
+                return u'Access Granted'
+
+            self.app.register_blueprint(first, url_prefix='/first')
+            self.app.register_blueprint(second, url_prefix='/second')
+
+            set_login_view('app_login')
+
+            with self.app.test_client() as c:
+
+                result = c.get('/first/unsecure')
+                self.assertEqual(result.status_code, 200)
+
+                result = c.get('/first/protected')
+                self.assertEqual(result.status_code, 302)
+                expected = ('http://localhost/'
+                            'app_login?next=%2Ffirst%2Fprotected')
+                self.assertEqual(result.location, expected)
+
+                result = c.get('/second/protected')
+                self.assertEqual(result.status_code, 302)
+                expected = ('http://localhost/'
+                            'app_login?next=%2Fsecond%2Fprotected')
                 self.assertEqual(result.location, expected)
 
     #


### PR DESCRIPTION
secure = Blueprint('secure', 'secure')
secure.before_request(blueprint_login_required)

all views from this blueprint only be accessible with logged user