### PR TITLE
user fails to logout

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -491,7 +491,7 @@ class LoginManager(object):
         config = current_app.config
         cookie_name = config.get('REMEMBER_COOKIE_NAME', COOKIE_NAME)
         domain = config.get('REMEMBER_COOKIE_DOMAIN')
-        
+
         # for multi-domain cookie, domain field should be None
         response.delete_cookie(cookie_name)
         response.delete_cookie(cookie_name, domain=domain)

--- a/flask_login.py
+++ b/flask_login.py
@@ -491,7 +491,11 @@ class LoginManager(object):
         config = current_app.config
         cookie_name = config.get('REMEMBER_COOKIE_NAME', COOKIE_NAME)
         domain = config.get('REMEMBER_COOKIE_DOMAIN')
+        
+        # for multi-domain cookie, domain field should be None
+        # https://github.com/mitsuhiko/werkzeug/blob/0.7-maintenance/werkzeug/wrappers.py#L846
         response.delete_cookie(cookie_name)
+        response.delete_cookie(cookie_name, domain=domain)
 
 
 class UserMixin(object):

--- a/flask_login.py
+++ b/flask_login.py
@@ -493,7 +493,6 @@ class LoginManager(object):
         domain = config.get('REMEMBER_COOKIE_DOMAIN')
         
         # for multi-domain cookie, domain field should be None
-        # https://github.com/mitsuhiko/werkzeug/blob/0.7-maintenance/werkzeug/wrappers.py#L846
         response.delete_cookie(cookie_name)
         response.delete_cookie(cookie_name, domain=domain)
 

--- a/flask_login.py
+++ b/flask_login.py
@@ -491,7 +491,7 @@ class LoginManager(object):
         config = current_app.config
         cookie_name = config.get('REMEMBER_COOKIE_NAME', COOKIE_NAME)
         domain = config.get('REMEMBER_COOKIE_DOMAIN')
-        response.delete_cookie(cookie_name, domain=domain)
+        response.delete_cookie(cookie_name)
 
 
 class UserMixin(object):


### PR DESCRIPTION
We found a bug that if you have the following config ```REMEMBER_COOKIE_DOMAIN = '.example.com'```, the user cookie will not be clear when logout. 

Then the user will remain in the login state.