### PR TITLE
is_authenticated and friends are methods, not properties

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -226,11 +226,11 @@ using the `Authorization` header::
 Anonymous Users
 ===============
 By default, when a user is not actually logged in, `current_user` is set to
-an `AnonymousUserMixin` object. It has the following properties:
+an `AnonymousUserMixin` object. It has the following methods:
 
-- `is_active` and `is_authenticated` return `False`
-- `is_anonymous` returns `True`
-- `get_id` returns `None`
+- `is_active()` and `is_authenticated()` return `False`
+- `is_anonymous()` returns `True`
+- `get_id()` returns `None`
 
 If you have custom requirements for anonymous users (for example, they need
 to have a permissions field), you can provide a callable (either a class or


### PR DESCRIPTION
`is_authenticated()` and friends are properties, not methods. The documentation mistakenly referred to them as properties. If you used them in a conditional as if they were properties, they would always evaluate to `True`.
