### PR TITLE
is_authenticated and friends as properties

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,13 @@ Flask-Login Changelog
 
 Here you can see the full list of changes between each Flask-Login release.
 
+Version -.-.--
+--------------
+
+- The `is_authenticated`, `is_active`, and `is_anonymous` members of the user
+  class are now properties, not methods. Applications should update their user
+  classes accordingly.
+
 Version 0.2.11
 --------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,20 +99,21 @@ They will be logged out, and any cookies for their session will be cleaned up.
 
 Your User Class
 ===============
-The class that you use to represent users needs to implement these methods:
+The class that you use to represent users needs to implement these properties
+and methods:
 
-`is_authenticated()`
+`is_authenticated`
     Returns `True` if the user is authenticated, i.e. they have provided
     valid credentials. (Only authenticated users will fulfill the criteria
     of `login_required`.)
 
-`is_active()`
+`is_active`
     Returns `True` if this is an active user - in addition to being
     authenticated, they also have activated their account, not been suspended,
     or any condition your application has for rejecting an account. Inactive
     accounts may not log in (without being forced of course).
 
-`is_anonymous()`
+`is_anonymous`
     Returns `True` if this is an anonymous user. (Actual users should return
     `False` instead.)
 
@@ -226,10 +227,10 @@ using the `Authorization` header::
 Anonymous Users
 ===============
 By default, when a user is not actually logged in, `current_user` is set to
-an `AnonymousUserMixin` object. It has the following methods:
+an `AnonymousUserMixin` object. It has the following properties and methods:
 
-- `is_active()` and `is_authenticated()` return `False`
-- `is_anonymous()` returns `True`
+- `is_active` and `is_authenticated` are `False`
+- `is_anonymous` is `True`
 - `get_id()` returns `None`
 
 If you have custom requirements for anonymous users (for example, they need

--- a/flask_login.py
+++ b/flask_login.py
@@ -499,12 +499,15 @@ class UserMixin(object):
     This provides default implementations for the methods that Flask-Login
     expects user objects to have.
     '''
+    @property
     def is_active(self):
         return True
 
+    @property
     def is_authenticated(self):
         return True
 
+    @property
     def is_anonymous(self):
         return False
 
@@ -541,12 +544,15 @@ class AnonymousUserMixin(object):
     '''
     This is the default object for representing an anonymous user.
     '''
+    @property
     def is_authenticated(self):
         return False
 
+    @property
     def is_active(self):
         return False
 
+    @property
     def is_anonymous(self):
         return True
 
@@ -673,7 +679,7 @@ def login_fresh():
 def login_user(user, remember=False, force=False):
     '''
     Logs a user in. You should pass the actual user object to this. If the
-    user's `is_active` method returns ``False``, they will not be logged in
+    user's `is_active` property is ``False``, they will not be logged in
     unless `force` is ``True``.
 
     This will return ``True`` if the log in attempt succeeds, and ``False`` if
@@ -688,7 +694,7 @@ def login_user(user, remember=False, force=False):
         them in regardless. Defaults to ``False``.
     :type force: bool
     '''
-    if not force and not user.is_active():
+    if not force and not user.is_active:
         return False
 
     user_id = getattr(user, current_app.login_manager.id_attribute)()
@@ -753,7 +759,7 @@ def login_required(func):
     If there are only certain times you need to require that your user is
     logged in, you can do so with::
 
-        if not current_user.is_authenticated():
+        if not current_user.is_authenticated:
             return current_app.login_manager.unauthorized()
 
     ...which is essentially the code that this function adds to your views.
@@ -770,7 +776,7 @@ def login_required(func):
     def decorated_view(*args, **kwargs):
         if current_app.login_manager._login_disabled:
             return func(*args, **kwargs)
-        elif not current_user.is_authenticated():
+        elif not current_user.is_authenticated:
             return current_app.login_manager.unauthorized()
         return func(*args, **kwargs)
     return decorated_view
@@ -798,7 +804,7 @@ def fresh_login_required(func):
     def decorated_view(*args, **kwargs):
         if current_app.login_manager._login_disabled:
             return func(*args, **kwargs)
-        elif not current_user.is_authenticated():
+        elif not current_user.is_authenticated:
             return current_app.login_manager.unauthorized()
         elif not login_fresh():
             return current_app.login_manager.needs_refresh()

--- a/test_login.py
+++ b/test_login.py
@@ -99,6 +99,7 @@ class User(UserMixin):
     def get_id(self):
         return self.id
 
+    @property
     def is_active(self):
         return self.active
 
@@ -126,7 +127,7 @@ class StaticTestCase(unittest.TestCase):
 
         with app.test_client() as c:
             c.get('/static/favicon.ico')
-            self.assertTrue(current_user.is_anonymous())
+            self.assertTrue(current_user.is_anonymous)
 
     def test_static_loads_without_accessing_session(self):
         app = Flask(__name__)
@@ -210,7 +211,7 @@ class LoginTestCase(unittest.TestCase):
 
         @self.app.route('/username')
         def username():
-            if current_user.is_authenticated():
+            if current_user.is_authenticated:
                 return current_user.name
             return u'Anonymous'
 
@@ -276,7 +277,7 @@ class LoginTestCase(unittest.TestCase):
     #
     def test_test_request_context_users_are_anonymous(self):
         with self.app.test_request_context():
-            self.assertTrue(current_user.is_anonymous())
+            self.assertTrue(current_user.is_anonymous)
 
     def test_defaults_anonymous(self):
         with self.app.test_client() as c:
@@ -298,7 +299,7 @@ class LoginTestCase(unittest.TestCase):
     def test_login_inactive_user(self):
         with self.app.test_request_context():
             result = login_user(creeper)
-            self.assertTrue(current_user.is_anonymous())
+            self.assertTrue(current_user.is_anonymous)
             self.assertFalse(result)
 
     def test_login_inactive_user_forced(self):
@@ -351,7 +352,7 @@ class LoginTestCase(unittest.TestCase):
         with self.app.test_request_context():
             login_user(notch)
             logout_user()
-            self.assertTrue(current_user.is_anonymous())
+            self.assertTrue(current_user.is_anonymous)
 
     def test_logout_emits_signal(self):
         with self.app.test_request_context():
@@ -1112,9 +1113,9 @@ class ExplicitIdUser(UserMixin):
 class UserMixinTestCase(unittest.TestCase):
     def test_default_values(self):
         user = ImplicitIdUser(1)
-        self.assertTrue(user.is_active())
-        self.assertTrue(user.is_authenticated())
-        self.assertFalse(user.is_anonymous())
+        self.assertTrue(user.is_active)
+        self.assertTrue(user.is_authenticated)
+        self.assertFalse(user.is_anonymous)
 
     def test_get_id_from_id_attribute(self):
         user = ImplicitIdUser(1)
@@ -1146,9 +1147,9 @@ class AnonymousUserTestCase(unittest.TestCase):
     def test_values(self):
         user = AnonymousUserMixin()
 
-        self.assertFalse(user.is_active())
-        self.assertFalse(user.is_authenticated())
-        self.assertTrue(user.is_anonymous())
+        self.assertFalse(user.is_active)
+        self.assertFalse(user.is_authenticated)
+        self.assertTrue(user.is_anonymous)
         self.assertIsNone(user.get_id())
 
 
@@ -1174,13 +1175,13 @@ class UnicodeCookieUserIDTestCase(unittest.TestCase):
 
         @self.app.route('/username')
         def username():
-            if current_user.is_authenticated():
+            if current_user.is_authenticated:
                 return current_user.name
             return u'Anonymous'
 
         @self.app.route('/userid')
         def user_id():
-            if current_user.is_authenticated():
+            if current_user.is_authenticated:
                 return current_user.id
             return u'wrong_id'
 


### PR DESCRIPTION
The documentation mistakenly referred to is_authenticated and friends as properties, when in reality they were methods. However, they make good sense as properties. This patch turns them into properties.

This is offered as an alternative to #175.
