### PR TITLE
Fix session creation for every user

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -385,16 +385,10 @@ class LoginManager(object):
         app = current_app._get_current_object()
         mode = app.config.get('SESSION_PROTECTION', self.session_protection)
 
-        # if there is no '_id', then take the current one for good
-        if '_id' not in sess:
-            sess['_id'] = ident
+        # if the sess is empty, it's an anonymous user or just logged out
+        # so we can skip this
 
-        # if the sess is empty, it's an anonymous user, or just logged out
-        #  so we can skip this, unless 'strong' protection is active,
-        #  in which case we need to double check for the remember me token
-        check_protection = sess or mode == 'strong'
-
-        if check_protection and ident != sess.get('_id', None):
+        if sess and ident != sess.get('_id', None):
             if mode == 'basic' or sess.permanent:
                 sess['_fresh'] = False
                 session_protected.send(app)

--- a/test_login.py
+++ b/test_login.py
@@ -882,9 +882,8 @@ class LoginTestCase(unittest.TestCase):
                 self.assertEqual(results.data.decode('utf-8'), u'Anonymous')
                 session_listener.assert_heard_none(self.app)
 
-            # verify no session data has been set other than '_id'
-            self.assertIsNotNone(session.get('_id'))
-            self.assertTrue(len(session) == 1)
+            # verify no session data has been set
+            self.assertFalse(session)
 
     #
     # Custom Token Loader


### PR DESCRIPTION
This fixes a wrong behavior in the strong protection. Now the
session protection is only tested if a session exists and
nothing is added to the session during the process.
Only one test is impacted and has been updated.