### PR TITLE
Explicit error message when a user loader callback has not been set

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -338,6 +338,11 @@ class LoginManager(object):
             if user_id is None:
                 ctx.user = self.anonymous_user()
             else:
+                if self.user_callback is None:
+                    raise Exception(
+                        "No user_loader has been installed for this "
+                        "LoginManager. Add one with the "
+                        "'LoginManager.user_loader' decorator.")
                 user = self.user_callback(user_id)
                 if user is None:
                     ctx.user = self.anonymous_user()

--- a/test_login.py
+++ b/test_login.py
@@ -172,7 +172,8 @@ class InitializationTestCase(unittest.TestCase):
             with self.assertRaises(Exception) as cm:
                 login_manager.reload_user()
             expected_exception_message = 'No user_loader has been installed'
-            self.assertIn(expected_exception_message, str(cm.exception))
+            self.assertTrue(
+                str(cm.exception).startswith(expected_exception_message))
 
 
 class LoginTestCase(unittest.TestCase):

--- a/test_login.py
+++ b/test_login.py
@@ -148,6 +148,7 @@ class InitializationTestCase(unittest.TestCase):
     def setUp(self):
         self.app = Flask(__name__)
         self.app.config['TESTING'] = True
+        self.app.config['SECRET_KEY'] = '1234'
 
     def test_init_app(self):
         login_manager = LoginManager()
@@ -163,6 +164,15 @@ class InitializationTestCase(unittest.TestCase):
     def test_login_disabled_is_set(self):
         login_manager = LoginManager(self.app, add_context_processor=True)
         self.assertFalse(login_manager._login_disabled)
+
+    def test_no_user_loader_raises(self):
+        login_manager = LoginManager(self.app, add_context_processor=True)
+        with self.app.test_request_context():
+            session['user_id'] = '2'
+            with self.assertRaises(Exception) as cm:
+                login_manager.reload_user()
+            expected_exception_message = 'No user_loader has been installed'
+            self.assertIn(expected_exception_message, str(cm.exception))
 
 
 class LoginTestCase(unittest.TestCase):


### PR DESCRIPTION
Fix for https://github.com/maxcountryman/flask-login/issues/62! A helpful error message is shown when a user loader callback has not been set. This prevents new flask-login users having to go through stackoverflow to decipher the `TypeError: 'NoneType'
object is not callable`



Implementation:
An explicit exception with a helpful error message is raised on
LoginManager.reload_user(), when the LoginManager.user_callback
has not been set.
Previously, the generic python exception (TypeError: 'NoneType'
object is not callable) gave no indication as to what the problem
might be.