### PR TITLE
Adding validation to HTML form

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -846,6 +846,7 @@ def set_login_view(login_view, blueprint=None):
     else:
         current_app.login_manager.login_view = login_view
 
+
 def form_page(template, login_route, **parameters_to_render_template):
     """
     If you decorate a view with this, this will ensure that your HTML form
@@ -858,18 +859,18 @@ def form_page(template, login_route, **parameters_to_render_template):
             pass
 
     This feature is useful when you prefer using HTML to forms. It also allows
-    less polluting your view, since it does not need to check which type 
+    less polluting your view, since it does not need to check which type
     of request or make validation of fields sent by HTML forms.
 
-    :param template: Indicates the template page which contains the form. 
+    :param template: Indicates the template page which contains the form.
         It is used if the request is of type "GET".
     :type template: string
-    :param login_route: Indicates the route belonging to the form page. 
+    :param login_route: Indicates the route belonging to the form page.
         It is used if the HTML form is not valid.
     :type login_route: string
-    :param parameters_to_render_template: Indicates the parameters to be 
-        passed to the template at the time of the request type "GET". 
-        For example, if we need to spend a title for our template, we use 
+    :param parameters_to_render_template: Indicates the parameters to be
+        passed to the template at the time of the request type "GET".
+        For example, if we need to spend a title for our template, we use
         these parameters. Defaults to "None".
     :type parameters_to_render_template: any type.
         """
@@ -887,13 +888,14 @@ def form_page(template, login_route, **parameters_to_render_template):
                 return func(*args, **kwargs)
             return render_template(template, **parameters_to_render_template)
         return decorated_view
-    return decorated_function 
+    return decorated_function
+
 
 def _valid_form(fields):
     """
     Check if form have empty fields.
 
-    :param fields: Indicates a past dictionary with the parameters of the 
+    :param fields: Indicates a past dictionary with the parameters of the
         request "POST".
     :type fields: dict
     """
@@ -903,6 +905,7 @@ def _valid_form(fields):
         if field_value.isspace() or not len(field_value):
             fields_errors[field] = field_value
     return bool(fields_errors)
+
 
 def _get_user():
     if has_request_context() and not hasattr(_request_ctx_stack.top, 'user'):

--- a/flask_login.py
+++ b/flask_login.py
@@ -852,7 +852,7 @@ def form_page(template, login_route, **parameters_to_render_template):
     has no fields blank, and allows the developer don't worry with the type
     of request is "POST" or "GET". For example::
 
-        @app.route('/login', methods=["GET","POST"])
+        @app.route('/register', methods=["GET","POST"])
         @form_page("register.html", ".register", title="Register user")
         def register():
             pass

--- a/flask_login.py
+++ b/flask_login.py
@@ -18,7 +18,8 @@ __copyright__ = '(c) 2011 by Matthew Frazier'
 __all__ = ['LoginManager']
 
 from flask import (_request_ctx_stack, abort, current_app, flash, redirect,
-                   request, session, url_for, has_request_context)
+                   request, session, url_for, has_request_context,
+                   render_template)
 from flask.signals import Namespace
 
 from werkzeug.local import LocalProxy
@@ -871,8 +872,8 @@ def form_page(template, login_route, **parameters_to_render_template):
     :param parameters_to_render_template: Indicates the parameters to be
         passed to the template at the time of the request type "GET".
         For example, if we need to spend a title for our template, we use
-        these parameters. Defaults to "None".
-    :type parameters_to_render_template: any type.
+        these parameters.
+    :type parameters_to_render_template: kwargs.
         """
     def decorated_function(func):
         """

--- a/flask_login.py
+++ b/flask_login.py
@@ -846,7 +846,7 @@ def set_login_view(login_view, blueprint=None):
     else:
         current_app.login_manager.login_view = login_view
 
-def form_page(template, login_route, **parameters_to_render_template=None):
+def form_page(template, login_route, **parameters_to_render_template):
     """
     If you decorate a view with this, this will ensure that your HTML form
     has no fields blank, and allows the developer don't worry with the type

--- a/flask_login.py
+++ b/flask_login.py
@@ -882,7 +882,7 @@ def form_page(template, login_route, **parameters_to_render_template):
         def decorated_view(*args, **kwargs):
             if request.method in ("POST", "PUT"):
                 fields = request.form.to_dict()
-                if not _valid_form(fields):
+                if _valid_form(fields):
                     return redirect(url_for(login_route))
                 return func(*args, **kwargs)
             return render_template(template, **parameters_to_render_template)

--- a/flask_login.py
+++ b/flask_login.py
@@ -846,6 +846,63 @@ def set_login_view(login_view, blueprint=None):
     else:
         current_app.login_manager.login_view = login_view
 
+def form_page(template, login_route, **parameters_to_render_template=None):
+    """
+    If you decorate a view with this, this will ensure that your HTML form
+    has no fields blank, and allows the developer don't worry with the type
+    of request is "POST" or "GET". For example::
+
+        @app.route('/login', methods=["GET","POST"])
+        @form_page("register.html", ".register", title="Register user")
+        def register():
+            pass
+
+    This feature is useful when you prefer using HTML to forms. It also allows
+    less polluting your view, since it does not need to check which type 
+    of request or make validation of fields sent by HTML forms.
+
+    :param template: Indicates the template page which contains the form. 
+        It is used if the request is of type "GET".
+    :type template: string
+    :param login_route: Indicates the route belonging to the form page. 
+        It is used if the HTML form is not valid.
+    :type login_route: string
+    :param parameters_to_render_template: Indicates the parameters to be 
+        passed to the template at the time of the request type "GET". 
+        For example, if we need to spend a title for our template, we use 
+        these parameters. Defaults to "None".
+    :type parameters_to_render_template: any type.
+        """
+    def decorated_function(func):
+        """
+        :param func: The view function to decorate.
+        :type func: function
+        """
+        @wraps(func)
+        def decorated_view(*args, **kwargs):
+            if request.method in ("POST", "PUT"):
+                fields = request.form.to_dict()
+                if not _valid_form(fields):
+                    return redirect(url_for(login_route))
+                return func(*args, **kwargs)
+            return render_template(template, **parameters_to_render_template)
+        return decorated_view
+    return decorated_function 
+
+def _valid_form(fields):
+    """
+    Check if form have empty fields.
+
+    :param fields: Indicates a past dictionary with the parameters of the 
+        request "POST".
+    :type fields: dict
+    """
+    fields_errors = {}
+    for field in fields:
+        field_value = fields[field]
+        if field_value.isspace() or not len(field_value):
+            fields_errors[field] = field_value
+    return bool(fields_errors)
 
 def _get_user():
     if has_request_context() and not hasattr(_request_ctx_stack.top, 'user'):


### PR DESCRIPTION
I see that many people when using the flask-login end up very pollute his view as do things like check for the type of request. Another thing that greatly pollutes the view is when the developer chooses to use an HTML form instead of using an instantiated class wtforms. For this reason he ends up doing the validation of these fields also in view, which ends up polluting it further. To work around this, I implemented a decorator that allows the developer to not worry about the type of request or with the validation of this field in the HTML form, allowing the same make in view only what he should do and nothing more.