### PR TITLE
Fix handling of X-Forwarded-For header

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -863,7 +863,9 @@ def _cookie_digest(payload, key=None):
 def _get_remote_addr():
     address = request.headers.get('X-Forwarded-For', request.remote_addr)
     if address is not None:
-        address = address.encode('utf-8')
+        # An 'X-Forwarded-For' header includes a comma separated list of the
+        # addresses, the first address being the actual remote address.
+        address = address.encode('utf-8').split(b',')[0].strip()
     return address
 
 

--- a/test_login.py
+++ b/test_login.py
@@ -614,6 +614,29 @@ class LoginTestCase(unittest.TestCase):
             self._delete_session(c)
             self.assertEqual(u'False', c.get('/is-fresh').data.decode('utf-8'))
 
+    def test_login_persists_with_signle_x_forwarded_for(self):
+        self.app.config['SESSION_PROTECTION'] = 'strong'
+        with self.app.test_client() as c:
+            c.get('/login-notch', headers=[('X-Forwarded-For', '10.1.1.1')])
+            result = c.get('/username',
+                           headers=[('X-Forwarded-For', '10.1.1.1')])
+            self.assertEqual(u'Notch', result.data.decode('utf-8'))
+            result = c.get('/username',
+                           headers=[('X-Forwarded-For', '10.1.1.1')])
+            self.assertEqual(u'Notch', result.data.decode('utf-8'))
+
+    def test_login_persists_with_many_x_forwarded_for(self):
+        self.app.config['SESSION_PROTECTION'] = 'strong'
+        with self.app.test_client() as c:
+            c.get('/login-notch',
+                  headers=[('X-Forwarded-For', '10.1.1.1')])
+            result = c.get('/username',
+                           headers=[('X-Forwarded-For', '10.1.1.1')])
+            self.assertEqual(u'Notch', result.data.decode('utf-8'))
+            result = c.get('/username',
+                           headers=[('X-Forwarded-For', '10.1.1.1, 10.1.1.2')])
+            self.assertEqual(u'Notch', result.data.decode('utf-8'))
+
     def test_user_loaded_from_cookie_fired(self):
         with self.app.test_client() as c:
             c.get('/login-notch-remember')


### PR DESCRIPTION
 The code that calculates a user's identifier uses the remote address or
 the contents of the X-Forwarded-For header doesn't account for the fact
that the X-Forwarded-For header can contain a comma separated list of
remote addresses, which is the case for scenarios in which 2+ proxy
servers are involved in the request forwarding. This caveat causes
Flask-Login to unexpectedly log users out when the combination of proxy
servers that routed a previous request change.
    
See http://tools.ietf.org/html/rfc7239 for more information about
X-Forwarded-For standard.