### PR TITLE
Docs still name `TESTING`

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -769,10 +769,9 @@ def login_required(func):
 
     ...which is essentially the code that this function adds to your views.
 
-    It can be convenient to globally turn off authentication when unit
-    testing. To enable this, if either of the application
-    configuration variables `LOGIN_DISABLED` or `TESTING` is set to
-    `True`, this decorator will be ignored.
+    It can be convenient to globally turn off authentication when unit testing.
+    To enable this, if the application configuration variable `LOGIN_DISABLED`
+    is set to `True`, this decorator will be ignored.
 
     :param func: The view function to decorate.
     :type func: function

--- a/test_login.py
+++ b/test_login.py
@@ -147,7 +147,6 @@ class InitializationTestCase(unittest.TestCase):
 
     def setUp(self):
         self.app = Flask(__name__)
-        self.app.config['TESTING'] = True
         self.app.config['SECRET_KEY'] = '1234'
 
     def test_init_app(self):
@@ -183,7 +182,6 @@ class LoginTestCase(unittest.TestCase):
         self.app = Flask(__name__)
         self.app.config['SECRET_KEY'] = 'deterministic'
         self.app.config['SESSION_PROTECTION'] = None
-        self.app.config['TESTING'] = True
         self.remember_cookie_name = 'remember'
         self.app.config['REMEMBER_COOKIE_NAME'] = self.remember_cookie_name
         self.login_manager = LoginManager()
@@ -1211,7 +1209,6 @@ class UnicodeCookieUserIDTestCase(unittest.TestCase):
         self.app = Flask(__name__)
         self.app.config['SECRET_KEY'] = 'deterministic'
         self.app.config['SESSION_PROTECTION'] = None
-        self.app.config['TESTING'] = True
         self.remember_cookie_name = 'remember'
         self.app.config['REMEMBER_COOKIE_NAME'] = self.remember_cookie_name
         self.login_manager = LoginManager()


### PR DESCRIPTION
As of 2fc6a7e06b560233eadb44f8eba74e2a1bce88be, the `TESTING` config variable is no longer used, but is still referenced by the docs for login_required, at least.