### PR TITLE
Improved grammar

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -165,7 +165,7 @@ For example::
 The default message flashed is ``Please log in to access this page.`` To
 customize the message, set `LoginManager.login_message`::
 
-    login_manager.login_message = u"Bonvolu ensaluti por uzi tio paĝo."
+    login_manager.login_message = u"Bonvolu ensaluti por uzi tiun paĝon."
 
 To customize the message category, set `LoginManager.login_message_category`::
 


### PR DESCRIPTION
That's how accusative and "that one" work in Esperanto. You could also replace "that one" (tiun) with "this one" (ĉi-tiun or tiun ĉi), but in my opinion that's much uglier.