### PR TITLE
do not clear entire session, just Flask-Login variables (fixes #231)

### DIFF
--- a/flask_login.py
+++ b/flask_login.py
@@ -400,7 +400,9 @@ class LoginManager(object):
                 session_protected.send(app)
                 return False
             elif mode == 'strong':
-                sess.clear()
+                sess.pop('user_id', None)
+                sess.pop('_id', None)
+                sess.pop('_fresh', None)
                 sess['remember'] = 'clear'
                 session_protected.send(app)
                 return True


### PR DESCRIPTION
This patch addresses the recurrent problem of Flask-Login clearing session data stored by the application or other extensions. I have also expanded one of the unit tests to ensure unrelated data in the session is not deleted.