### PR TITLE
Extract login_user_in_session to log users in in tests.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -408,6 +408,19 @@ e.g. ``gettext``. This function will be called with the message and its return
 value will be sent to ``flash`` instead.
 
 
+Testing
+=======
+To log a user in from a test case, assuming `user` is the user object:
+
+    with app.test_client() as c:
+        with c.session_transaction() as session:
+            flask_login.login_user_in_session(session, user)
+
+This pattern is described in more detail in `Flask documentation`_.
+
+.. _Flask documentation: http://flask.pocoo.org/docs/testing/#accessing-and-modifying-sessions
+
+
 API Documentation
 =================
 This documentation is automatically generated from Flask-Login's source code.

--- a/test_login.py
+++ b/test_login.py
@@ -23,6 +23,7 @@ from flask.views import MethodView
 
 from flask.ext.login import (LoginManager, UserMixin, AnonymousUserMixin,
                              make_secure_token, current_user, login_user,
+                             login_user_in_session,
                              logout_user, user_logged_in, user_logged_out,
                              user_loaded_from_cookie, user_login_confirmed,
                              user_loaded_from_header, user_loaded_from_request,
@@ -202,6 +203,36 @@ class MethodViewLoginTestCase(unittest.TestCase):
         with self.app.test_client() as c:
             result = c.open('/secret', method='OPTIONS')
             self.assertEqual(result.status_code, 200)
+
+
+class LoginInSessionTestCase(unittest.TestCase):
+    ''' Tests for login_user_in_session function '''
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.config['SECRET_KEY'] = 'deterministic'
+        self.login_manager = LoginManager()
+        self.login_manager.init_app(self.app)
+
+        unittest.TestCase.setUp(self)
+
+    def test_login_user_in_session(self):
+        with self.app.test_request_context():
+            session = {}
+            login_user_in_session(session, notch)
+            self.assertTrue('user_id' in session)
+            self.assertTrue('_fresh' in session)
+            self.assertTrue('_id' in session)
+            self.assertTrue('remember' not in session)
+
+    def test_login_user_in_session_remember(self):
+        with self.app.test_request_context():
+            session = {}
+            login_user_in_session(session, notch, remember=True)
+            self.assertTrue('user_id' in session)
+            self.assertTrue('_fresh' in session)
+            self.assertTrue('_id' in session)
+            self.assertTrue(session['remember'])
 
 
 class LoginTestCase(unittest.TestCase):


### PR DESCRIPTION
This makes it possible to use the session transaction pattern
mentioned here:
http://flask.pocoo.org/docs/0.10/testing/#accessing-and-modifying-sessions