### PR TITLE
rename mixin to be plural

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ test: clean_coverage
 clean_coverage:
 	@rm -f .coverage
 
+clean:
+	@rm -f flask_login/*.pyc
+
 pep8:
 	@echo 'Checking pep8 compliance...'
 	@pep8 flask_login/* test_login.py
@@ -23,4 +26,4 @@ pyflakes:
 	@echo 'Running pyflakes...'
 	@pyflakes flask_login/* test_login.py
 
-check: pep8 pyflakes test
+check: clean pep8 pyflakes test

--- a/flask_login/__init__.py
+++ b/flask_login/__init__.py
@@ -17,7 +17,7 @@ from .config import (COOKIE_NAME, COOKIE_DURATION, COOKIE_SECURE,
                      REFRESH_MESSAGE, REFRESH_MESSAGE_CATEGORY, ID_ATTRIBUTE,
                      AUTH_HEADER_NAME)
 from .login_manager import LoginManager
-from .mixin import UserMixin, AnonymousUserMixin
+from .mixins import UserMixin, AnonymousUserMixin
 from .signals import (user_logged_in, user_logged_out, user_loaded_from_cookie,
                       user_loaded_from_header, user_loaded_from_request,
                       user_login_confirmed, user_unauthorized,

--- a/flask_login/login_manager.py
+++ b/flask_login/login_manager.py
@@ -17,7 +17,7 @@ from .config import (COOKIE_NAME, COOKIE_DURATION, COOKIE_SECURE,
                      COOKIE_HTTPONLY, LOGIN_MESSAGE, LOGIN_MESSAGE_CATEGORY,
                      REFRESH_MESSAGE, REFRESH_MESSAGE_CATEGORY, ID_ATTRIBUTE,
                      AUTH_HEADER_NAME, SESSION_KEYS)
-from .mixin import AnonymousUserMixin
+from .mixins import AnonymousUserMixin
 from .signals import (user_loaded_from_cookie, user_loaded_from_header,
                       user_loaded_from_request, user_unauthorized,
                       user_needs_refresh, user_accessed, session_protected)

--- a/flask_login/mixins.py
+++ b/flask_login/mixins.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-    flask.ext.login.mixin
-    ---------------------
+    flask.ext.login.mixins
+    ----------------------
     This module provides mixin objects.
 '''
 


### PR DESCRIPTION
Also runs the `clean` build step when running `make check` to clean up `*.pyc` files so you can run tests multiple times without having to delete compiled modules manually.