### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ If you'd like to submit PR, please make sure that all tests pass prior to submis
 
 ## Extended Documentation
 
-Sphinx-generated documentation can be found [here](http://flask-login.readthedocs.org/en/latest/). This page is updated automatically. Documentation for prior versions of the library may be found there as well. Always review this page when a problem is first encountered.
+Sphinx-generated documentation can be found [here](https://flask-login.readthedocs.io/en/latest/). This page is updated automatically. Documentation for prior versions of the library may be found there as well. Always review this page when a problem is first encountered.
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ def unauthorized_handler():
     return 'Unauthorized'
 ```
 
-Complete documentation for Flask-Login is availble on [ReadTheDocs](http://flask-login.readthedocs.org/en/latest/).
+Complete documentation for Flask-Login is availble on [ReadTheDocs](https://flask-login.readthedocs.io/en/latest/).
 
 
 ## Contributing


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.