### PR TITLE
Set session[user_id] in _load_from_request/_load_from_header

### DIFF
--- a/flask_login/login_manager.py
+++ b/flask_login/login_manager.py
@@ -326,7 +326,7 @@ class LoginManager(object):
                 return self._load_from_cookie(request.cookies[cookie_name])
             elif self.request_callback:
                 return self._load_from_request(request)
-            elif header_name in request.headers:
+            elif self.header_callback and header_name in request.headers:
                 return self._load_from_header(request.headers[header_name])
 
         return self.reload_user()
@@ -378,26 +378,20 @@ class LoginManager(object):
             user_loaded_from_cookie.send(app, user=_get_user())
 
     def _load_from_header(self, header):
-        user = None
-        if self.header_callback:
-            user = self.header_callback(header)
+        user = self.header_callback(header)
+        self.reload_user(user=user)
         if user is not None:
-            self.reload_user(user=user)
+            session['user_id'] = getattr(user, self.id_attribute)()
             app = current_app._get_current_object()
             user_loaded_from_header.send(app, user=_get_user())
-        else:
-            self.reload_user()
 
     def _load_from_request(self, request):
-        user = None
-        if self.request_callback:
-            user = self.request_callback(request)
+        user = self.request_callback(request)
+        self.reload_user(user=user)
         if user is not None:
-            self.reload_user(user=user)
+            session['user_id'] = getattr(user, self.id_attribute)()
             app = current_app._get_current_object()
             user_loaded_from_request.send(app, user=_get_user())
-        else:
-            self.reload_user()
 
     def _update_remember_cookie(self, response):
         # Don't modify the session unless there's something to do.

--- a/test_login.py
+++ b/test_login.py
@@ -363,7 +363,7 @@ class LoginTestCase(unittest.TestCase):
             result = c.get('/username', headers=headers)
             self.assertEqual(user_name, result.data.decode('utf-8'))
 
-            # Make a consequent request, but already without headers to ensure
+            # Make a consequent request, but already w/o headers to ensure
             # that current session is not anonymous for now. @See d8be747
             result = c.get('/username')
             self.assertEqual(user_name, result.data.decode('utf-8'))
@@ -387,7 +387,7 @@ class LoginTestCase(unittest.TestCase):
             result = c.get(url)
             self.assertEqual(user_name, result.data.decode('utf-8'))
 
-            # Make a consequent request, but already without auth params to ensure
+            # Make a consequent request, but already w/o auth params to ensure
             # that current session is not anonymous for now. @See d8be747
             result = c.get('/username')
             self.assertEqual(user_name, result.data.decode('utf-8'))

--- a/test_login.py
+++ b/test_login.py
@@ -363,6 +363,11 @@ class LoginTestCase(unittest.TestCase):
             result = c.get('/username', headers=headers)
             self.assertEqual(user_name, result.data.decode('utf-8'))
 
+            # Make a consequent request, but already without headers to ensure
+            # that current session is not anonymous for now. @See d8be747
+            result = c.get('/username')
+            self.assertEqual(user_name, result.data.decode('utf-8'))
+
     def test_login_invalid_user_with_header(self):
         user_id = 9000
         user_name = u'Anonymous'
@@ -380,6 +385,11 @@ class LoginTestCase(unittest.TestCase):
         with self.app.test_client() as c:
             url = '/username?user_id={user_id}'.format(user_id=user_id)
             result = c.get(url)
+            self.assertEqual(user_name, result.data.decode('utf-8'))
+
+            # Make a consequent request, but already without auth params to ensure
+            # that current session is not anonymous for now. @See d8be747
+            result = c.get('/username')
             self.assertEqual(user_name, result.data.decode('utf-8'))
 
     def test_login_invalid_user_with_request(self):


### PR DESCRIPTION
After successful loading user via _load_from_request() or _load_from_header() set session['user_id'] equals to user.get_id().
Also slightly simplify and unify these two methods.