### PR TITLE
remove get_auth_token because it can be used incorrectly to create…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,11 @@ Version 0.x.y
 
 Released on TBD.
 
+- BREAKING: The `login_manager.token_handler` function, `get_auth_token` method
+  on the User class, and the `utils.make_secure_token` utility function have
+  been removed to prevent users from creating insecure auth implementations.
+  Use the `Alternative Tokens` example from the docs instead. #291
+  
 
 Version 0.3.2
 -------------

--- a/flask_login/__init__.py
+++ b/flask_login/__init__.py
@@ -18,10 +18,10 @@ from .signals import (user_logged_in, user_logged_out, user_loaded_from_cookie,
                       user_loaded_from_header, user_loaded_from_request,
                       user_login_confirmed, user_unauthorized,
                       user_needs_refresh, user_accessed, session_protected)
-from .utils import (current_user, login_url, make_secure_token,
-                    login_fresh, login_user, logout_user, confirm_login,
-                    login_required, fresh_login_required, set_login_view,
-                    encode_cookie, decode_cookie, make_next_param)
+from .utils import (current_user, login_url, login_fresh, login_user,
+                    logout_user, confirm_login, login_required,
+                    fresh_login_required, set_login_view, encode_cookie,
+                    decode_cookie, make_next_param)
 
 
 __all__ = [
@@ -50,7 +50,6 @@ __all__ = [
     'session_protected',
     'current_user',
     'login_url',
-    'make_secure_token',
     'login_fresh',
     'login_user',
     'logout_user',

--- a/flask_login/utils.py
+++ b/flask_login/utils.py
@@ -106,35 +106,6 @@ def login_url(login_view, next_url=None, next_field='next'):
     return urlunparse(parts)
 
 
-def make_secure_token(*args, **options):
-    '''
-    This will create a secure token that you can use as an authentication
-    token for your users. It uses heavy-duty HMAC encryption to prevent people
-    from guessing the information. (To make it even more effective, if you
-    will never need to regenerate the token, you can  pass some random data
-    as one of the arguments.)
-
-    :param \*args: The data to include in the token.
-    :type args: args
-    :param \*\*options: To manually specify a secret key, pass ``key=THE_KEY``.
-        Otherwise, the ``current_app`` secret key will be used.
-    :type \*\*options: kwargs
-    '''
-    key = options.get('key')
-    key = _secret_key(key)
-
-    l = [s if isinstance(s, bytes) else s.encode('utf-8') for s in args]
-
-    payload = b'\0'.join(l)
-
-    token_value = hmac.new(key, payload, sha512).hexdigest()
-
-    if hasattr(token_value, 'decode'):  # pragma: no cover
-        token_value = token_value.decode('utf-8')  # ensure bytes
-
-    return token_value
-
-
 def login_fresh():
     '''
     This returns ``True`` if the current login is fresh.


### PR DESCRIPTION
…insecure authentication implementations.

Providing an example of using alternative tokens with existing `user_loader` in the docs.

Related to #285 and #155.