### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ def unauthorized_handler():
     return 'Unauthorized'
 ```
 
-Complete documentation for Flask-Login is availble on [ReadTheDocs](https://flask-login.readthedocs.io/en/latest/).
+Complete documentation for Flask-Login is available on [ReadTheDocs](https://flask-login.readthedocs.io/en/latest/).
 
 
 ## Contributing


### PR DESCRIPTION
There's a small typo in the README: availble -> available