### PR TITLE
Use HTTPS link for GitHub ribbon image

### DIFF
--- a/docs/_themes/flask_small/layout.html
+++ b/docs/_themes/flask_small/layout.html
@@ -14,8 +14,8 @@
 {% block relbar1 %}{% endblock %}
 {% block relbar2 %}
   {% if theme_github_fork %}
-    <a href="http://github.com/{{ theme_github_fork }}"><img style="position: fixed; top: 0; right: 0; border: 0;"
-    src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/{{ theme_github_fork }}"><img style="position: fixed; top: 0; right: 0; border: 0;"
+    src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
   {% endif %}
 {% endblock %}
 {% block sidebar1 %}{% endblock %}


### PR DESCRIPTION
This prevents the mixed content warning when the docs are hosted on an HTTPS site (like [Read The Docs](https://flask-login.readthedocs.io/en/latest/)).

Also, use an HTTPS link for the GitHub project.