### PR TITLE
Remove mirror use for pip since that is no longer a pip option. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ python:
   - 3.5
 install:
   - python install_requirements.py dev
-  - pip install . --use-mirrors
 script: make check

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -16,4 +16,4 @@ is_dev = sys.argv[1] == "dev" if len(sys.argv) > 1 else False
 if __name__ == "__main__":
     if is_dev:
         requirements = "dev-%s" % requirements
-    os.system("pip install -r %s --use-mirrors" % requirements)
+    os.system("pip install -r %s" % requirements)


### PR DESCRIPTION
And removed the call to pip from .travis.yml since that is handled by install_requirements.py. Pypi uses a CDN now so mirrors are no longer used and the use-mirrors option is no longer available for pip.