### PR TITLE
docs are hosted on readthedocs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ loading users from their ID.
 
 Links
 `````
-* `documentation <http://packages.python.org/Flask-Login>`_
+* `documentation <https://flask-login.readthedocs.io/en/latest/>`_
 * `development version <https://github.com/maxcountryman/flask-login>`_
 '''
 import os


### PR DESCRIPTION
This will update the links on pypi on the next release.