### PR TITLE
upgrade python requirements to latest versions

### DIFF
--- a/dev-py2-requirements.txt
+++ b/dev-py2-requirements.txt
@@ -1,0 +1,3 @@
+-r dev-requirements.txt
+
+unittest2==1.1.0

--- a/dev-py3k-requirements.txt
+++ b/dev-py3k-requirements.txt
@@ -1,9 +1,0 @@
-flask==0.10.1
-blinker==1.2
-coverage==3.6
-mock==1.0.1
-nose==1.2.1
-pep8==1.4.2
-pyflakes==1.1.0
-yanc==0.2.3
-werkzeug==0.9.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,10 @@
-flask==0.9
-blinker==1.2
-coverage==3.7
-mock==1.0.1
-nose==1.3.0
-pep8==1.4.2
-pyflakes==1.1.0
-unittest2==0.5.1
-yanc==0.2.4
-werkzeug==0.8.3
+-r requirements.txt
+
+blinker==1.4
+coverage==4.2
+mock==2.0.0
+nose==1.3.7
+pep8==1.7.0
+pyflakes==1.3.0
+semantic_version==2.6.0
+yanc==0.3.3

--- a/flask_login/login_manager.py
+++ b/flask_login/login_manager.py
@@ -26,10 +26,9 @@ from .utils import (_get_user, login_url, _create_identifier,
 
 
 class LoginManager(object):
-    '''
-    This object is used to hold the settings used for logging in. Instances of
-    :class:`LoginManager` are *not* bound to specific apps, so you can create
-    one in the main body of your code and then bind it to your
+    '''This object is used to hold the settings used for logging in. Instances
+    of :class:`LoginManager` are *not* bound to specific apps, so you can
+    create one in the main body of your code and then bind it to your
     app in a factory function.
     '''
     def __init__(self, app=None, add_context_processor=True):
@@ -406,7 +405,7 @@ class LoginManager(object):
         except TypeError:
             raise Exception('REMEMBER_COOKIE_DURATION must be a ' +
                             'datetime.timedelta, instead got: {0}'.format(
-                            duration))
+                                duration))
 
         # actually set it
         response.set_cookie(cookie_name,

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -2,15 +2,18 @@ import sys
 import os
 
 
+is_dev = sys.argv[1] == "dev" if len(sys.argv) > 1 else False
+
+
 if sys.version_info >= (3, 3):
-    requirements = "py3k-requirements.txt"
-elif (2, 6) <= sys.version_info < (3, 0):
     requirements = "requirements.txt"
+elif (2, 6) <= sys.version_info < (3, 0):
+    if is_dev:
+        requirements = "py2-requirements.txt"
+    else:
+        requirements = "requirements.txt"
 else:
     raise AssertionError("only support 2.6, 2.7, 3.3")
-
-
-is_dev = sys.argv[1] == "dev" if len(sys.argv) > 1 else False
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-flask==0.9
-werkzeug==0.8.3
+flask==0.11.1
+werkzeug==0.11.11

--- a/test_login.py
+++ b/test_login.py
@@ -9,6 +9,7 @@ import collections
 from datetime import timedelta, datetime
 from contextlib import contextmanager
 from mock import ANY
+from semantic_version import Version
 
 
 from werkzeug import __version__ as werkzeug_version
@@ -644,10 +645,9 @@ class LoginTestCase(unittest.TestCase):
                 session['user_id'] = 2
                 self.login_manager._set_cookie(None)
 
-            expected_exception_message = 'Exception: ' \
-                'REMEMBER_COOKIE_DURATION  must be a datetime.timedelta, ' \
-                'instead got: 123'
-            self.assertIn(expected_exception_message, str(cm.exception))
+        expected_exception_message = 'REMEMBER_COOKIE_DURATION must be a ' \
+            'datetime.timedelta, instead got: 123'
+        self.assertIn(expected_exception_message, str(cm.exception))
 
     def test_remember_me_is_unfresh(self):
         with self.app.test_client() as c:
@@ -1042,14 +1042,14 @@ class LoginTestCase(unittest.TestCase):
     #
     # Misc
     #
-    @unittest.skipIf(werkzeug_version.startswith("0.9"),
+    @unittest.skipIf(Version(werkzeug_version) >= Version('0.9', partial=True),
                      "wait for upstream implementing RFC 5987")
     def test_chinese_user_agent(self):
         with self.app.test_client() as c:
             result = c.get('/', headers=[('User-Agent', u'中文')])
             self.assertEqual(u'Welcome!', result.data.decode('utf-8'))
 
-    @unittest.skipIf(werkzeug_version.startswith("0.9"),
+    @unittest.skipIf(Version(werkzeug_version) >= Version('0.9', partial=True),
                      "wait for upstream implementing RFC 5987")
     def test_russian_cp1251_user_agent(self):
         with self.app.test_client() as c:

--- a/tox.ini
+++ b/tox.ini
@@ -2,21 +2,21 @@
 envlist = py26,py27,py33,pypy
 
 [testenv:py26]
-deps = -r{toxinidir}/dev-requirements.txt
+deps = -r{toxinidir}/dev-py2-requirements.txt
 commands =
     make check
 
 [testenv:py27]
-deps = -r{toxinidir}/dev-requirements.txt
+deps = -r{toxinidir}/dev-py2-requirements.txt
 commands =
     make check
 
 [testenv:pypy]
-deps = -r{toxinidir}/dev-requirements.txt
+deps = -r{toxinidir}/dev-py2-requirements.txt
 commands =
     make check
 
 [testenv:py33]
-deps = -r{toxinidir}/dev-py3k-requirements.txt
+deps = -r{toxinidir}/dev-requirements.txt
 commands =
     make check


### PR DESCRIPTION
* upgrade python requirements
* remove duplicate requirements by recursively specifying requirements
  files
* use semantic_version for more robust test skipping