### PR TITLE
Allow nosetests executable path to be specified

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -30,7 +30,7 @@ else
 fi
 
 log "Running tests..."
-nosetests $NOSETEST_OPTIONS 2>&1 | tee -a $OUTPUT_PATH/test.log
+"${NOSETESTS:-nosetests}" $NOSETEST_OPTIONS 2>&1 | tee -a $OUTPUT_PATH/test.log
 ret=${PIPESTATUS[0]}
 
 echo


### PR DESCRIPTION
Under distributions like Debian the Python 3 version of `nosetests` is installed as `nosetests3`. This change allows the hardcoded name `nostetests` to be overridden with an environment variable `NOSETESTS` when calling the test runner script to accommodate running the tests in this case.