### PR TITLE
Add option to store 'next' in session rather than the url.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -185,7 +185,9 @@ To customize the message category, set `LoginManager.login_message_category`::
     login_manager.login_message_category = "info"
 
 When the log in view is redirected to, it will have a ``next`` variable in the
-query string, which is the page that the user was trying to access.
+query string, which is the page that the user was trying to access. Alternatively,
+if `USE_SESSION_FOR_NEXT` is `True`, the page is stored in the session under the
+key ``next``.
 
 If you would like to customize the process further, decorate a function with
 `LoginManager.unauthorized_handler`::

--- a/flask_login/config.py
+++ b/flask_login/config.py
@@ -42,8 +42,13 @@ AUTH_HEADER_NAME = 'Authorization'
 
 #: A set of session keys that are populated by Flask-Login. Use this set to
 #: purge keys safely and accurately.
-SESSION_KEYS = set(['user_id', 'remember', '_id', '_fresh'])
+SESSION_KEYS = set(['user_id', 'remember', '_id', '_fresh', 'next'])
 
 #: A set of HTTP methods which are exempt from `login_required` and
 #: `fresh_login_required`. By default, this is just ``OPTIONS``.
 EXEMPT_METHODS = set(['OPTIONS'])
+
+#: If true, the page the user is attempting to access is stored in the session
+#: rather than a url parameter when redirecting to the login view; defaults to
+#: ``False``.
+USE_SESSION_FOR_NEXT = False

--- a/flask_login/utils.py
+++ b/flask_login/utils.py
@@ -75,6 +75,20 @@ def make_next_param(login_url, current_url):
     return current_url
 
 
+def expand_login_view(login_view):
+    '''
+    Returns the url for the login view, expanding the view name to a url if
+    needed.
+
+    :param login_view: The name of the login view or a URL for the login view.
+    :type login_view: str
+    '''
+    if login_view.startswith(('https://', 'http://', '/')):
+        return login_view
+    else:
+        return url_for(login_view)
+
+
 def login_url(login_view, next_url=None, next_field='next'):
     '''
     Creates a URL for redirecting to a login page. If only `login_view` is
@@ -91,10 +105,7 @@ def login_url(login_view, next_url=None, next_field='next'):
                        ``next``.)
     :type next_field: str
     '''
-    if login_view.startswith(('https://', 'http://', '/')):
-        base = login_view
-    else:
-        base = url_for(login_view)
+    base = expand_login_view(login_view)
 
     if next_url is None:
         return base

--- a/test_login.py
+++ b/test_login.py
@@ -475,6 +475,21 @@ class LoginTestCase(unittest.TestCase):
             self.assertEqual(result.location,
                              'http://localhost/login?next=%2Fsecret')
 
+    def test_unauthorized_with_next_in_session(self):
+        self.login_manager.login_view = 'login'
+        self.app.config['USE_SESSION_FOR_NEXT'] = True
+
+        @self.app.route('/login')
+        def login():
+            return session.pop('next', '')
+
+        with self.app.test_client() as c:
+            result = c.get('/secret')
+            self.assertEqual(result.status_code, 302)
+            self.assertEqual(result.location,
+                             'http://localhost/login')
+            self.assertEqual(c.get('/login').data.decode('utf-8'), '/secret')
+
     def test_unauthorized_uses_blueprint_login_view(self):
         with self.app.app_context():
 


### PR DESCRIPTION
I'm a fan of "pretty" urls and would prefer that it just says www.example.com/login and not a long parameter string. This was already requested in issue #123.

I added a config variable `USE_SESSION_FOR_NEXT` which defaults to false, but when set to true engages the feature.

I had to do some minor refactoring of utils to avoid duplication.

I added a test and updated the docs.