### PR TITLE
Fixed omission in USE_SESSION_FOR_NEXT

### DIFF
--- a/flask_login/login_manager.py
+++ b/flask_login/login_manager.py
@@ -274,7 +274,15 @@ class LoginManager(object):
             flash(self.needs_refresh_message,
                   category=self.needs_refresh_message_category)
 
-        return redirect(login_url(self.refresh_view, request.url))
+        config = current_app.config
+        if config.get('USE_SESSION_FOR_NEXT', USE_SESSION_FOR_NEXT):
+            session['next'] = make_next_param(
+                expand_login_view(self.refresh_view), request.url)
+            redirect_url = login_url(self.refresh_view)
+        else:
+            redirect_url = login_url(self.refresh_view, request.url)
+
+        return redirect(redirect_url)
 
     def reload_user(self, user=None):
         ctx = _request_ctx_stack.top

--- a/flask_login/login_manager.py
+++ b/flask_login/login_manager.py
@@ -276,8 +276,8 @@ class LoginManager(object):
 
         config = current_app.config
         if config.get('USE_SESSION_FOR_NEXT', USE_SESSION_FOR_NEXT):
-            session['next'] = make_next_param(
-                expand_login_view(self.refresh_view), request.url)
+            url = expand_login_view(self.refresh_view)
+            session['next'] = make_next_param(url, request.url)
             redirect_url = login_url(self.refresh_view)
         else:
             redirect_url = login_url(self.refresh_view, request.url)

--- a/test_login.py
+++ b/test_login.py
@@ -805,6 +805,22 @@ class LoginTestCase(unittest.TestCase):
             expected = 'http://localhost/refresh-view?next=%2Fneeds-refresh'
             self.assertEqual(result.location, expected)
 
+    def test_refresh_with_next_in_session(self):
+        @self.app.route('/refresh-view')
+        def refresh_view():
+            return session.pop('next', '')
+
+        self.login_manager.refresh_view = 'refresh_view'
+        self.app.config['USE_SESSION_FOR_NEXT'] = True
+
+        with self.app.test_client() as c:
+            c.get('/login-notch-remember')
+            result = c.get('/needs-refresh')
+            self.assertEqual(result.status_code, 302)
+            self.assertEqual(result.location, 'http://localhost/refresh-view')
+            result = c.get('/refresh-view')
+            self.assertEqual(result.data.decode('utf-8'), '/needs-refresh')
+
     def test_confirm_login(self):
         with self.app.test_client() as c:
             c.get('/login-notch-remember')


### PR DESCRIPTION
My last PR #330 had an error on my part. I didn't realize that fresh logins were handled separately. I updated that function to use the session as well and added a test for this.

Sorry about that.

I did a ctrl-F audit of `login_manager.py` and it looks I have caught all instances of `login_url` so I think we are good now.
