### PR TITLE
Fixed vulnerability for Host Header Poisoning.

### DIFF
--- a/flask_login/login_manager.py
+++ b/flask_login/login_manager.py
@@ -163,8 +163,12 @@ class LoginManager(object):
                       category=self.login_message_category)
             else:
                 flash(self.login_message, category=self.login_message_category)
-
         config = current_app.config
+        if config.get('FORCE_HOSTNAME'):
+            url_clean = request.url.replace('http://', '').replace('https://','')
+            if not url_clean.startswith(config['FORCE_HOSTNAME']):
+                raise Exception('HOSTNAME MISSMATCH. Possible Host Header Poisoning')
+
         if config.get('USE_SESSION_FOR_NEXT', USE_SESSION_FOR_NEXT):
             login_url = expand_login_view(login_view)
             session['next'] = make_next_param(login_url, request.url)
@@ -275,6 +279,11 @@ class LoginManager(object):
                   category=self.needs_refresh_message_category)
 
         config = current_app.config
+        if config.get('FORCE_HOSTNAME'):
+            url_clean = request.url.replace('http://', '').replace('https://','')
+            if not url_clean.startswith(config['FORCE_HOSTNAME']):
+                raise Exception('HOSTNAME MISSMATCH. Possible Host Header Poisoning')
+
         if config.get('USE_SESSION_FOR_NEXT', USE_SESSION_FOR_NEXT):
             login_url = expand_login_view(self.refresh_view)
             session['next'] = make_next_param(login_url, request.url)


### PR DESCRIPTION
The some redirects in flask-login are based on request.url.
The request.url can be controlled and motified by the user.
This can lead to arbitrary redirects, cache poisoning and social engineering.

To protection can be activated by setting the "FORCE_HOSTNAME" parameter in the config.