### PR TITLE
Add support for refreshing the remember me cookie on every request.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -358,26 +358,30 @@ Cookie Settings
 ===============
 The details of the cookie can be customized in the application settings.
 
-=========================== =================================================
-`REMEMBER_COOKIE_NAME`      The name of the cookie to store the "remember me"
-                            information in. **Default:** ``remember_token``
-`REMEMBER_COOKIE_DURATION`  The amount of time before the cookie expires, as
-                            a `datetime.timedelta` object.
-                            **Default:** 365 days (1 non-leap Gregorian year)
-`REMEMBER_COOKIE_DOMAIN`    If the "Remember Me" cookie should cross domains,
-                            set the domain value here (i.e. ``.example.com``
-                            would allow the cookie to be used on all
-                            subdomains of ``example.com``).
-                            **Default:** `None`
-`REMEMBER_COOKIE_PATH`      Limits the "Remember Me" cookie to a certain path.
-                            **Default:** ``/``
-`REMEMBER_COOKIE_SECURE`    Restricts the "Remember Me" cookie's scope to
-                            secure channels (typically HTTPS).
-                            **Default:** `None`
-`REMEMBER_COOKIE_HTTPONLY`  Prevents the "Remember Me" cookie from being
-                            accessed by client-side scripts.
-                            **Default:** `False`
-=========================== =================================================
+====================================== =================================================
+`REMEMBER_COOKIE_NAME`                 The name of the cookie to store the "remember me"
+                                       information in. **Default:** ``remember_token``
+`REMEMBER_COOKIE_DURATION`             The amount of time before the cookie expires, as
+                                       a `datetime.timedelta` object.
+                                       **Default:** 365 days (1 non-leap Gregorian year)
+`REMEMBER_COOKIE_DOMAIN`               If the "Remember Me" cookie should cross domains,
+                                       set the domain value here (i.e. ``.example.com``
+                                       would allow the cookie to be used on all
+                                       subdomains of ``example.com``).
+                                       **Default:** `None`
+`REMEMBER_COOKIE_PATH`                 Limits the "Remember Me" cookie to a certain path.
+                                       **Default:** ``/``
+`REMEMBER_COOKIE_SECURE`               Restricts the "Remember Me" cookie's scope to
+                                       secure channels (typically HTTPS).
+                                       **Default:** `None`
+`REMEMBER_COOKIE_HTTPONLY`             Prevents the "Remember Me" cookie from being
+                                       accessed by client-side scripts.
+                                       **Default:** `False`
+`REMEMBER_COOKIE_REFRESH_EACH_REQUEST` If set to `True` the cookie is refreshed on every
+                                       request, which bumps the lifetime. Works like
+                                       Flask's `SESSION_REFRESH_EACH_REQUEST`.
+                                       **Default:** `False`
+====================================== =================================================
 
 
 Session Protection

--- a/flask_login/login_manager.py
+++ b/flask_login/login_manager.py
@@ -401,6 +401,10 @@ class LoginManager(object):
 
     def _update_remember_cookie(self, response):
         # Don't modify the session unless there's something to do.
+        if 'remember' not in session and \
+                current_app.config.get('REMEMBER_COOKIE_REFRESH_EACH_REQUEST'):
+            session['remember'] = 'set'
+
         if 'remember' in session:
             operation = session.pop('remember', None)
 

--- a/test_login.py
+++ b/test_login.py
@@ -8,7 +8,7 @@ import base64
 import collections
 from datetime import timedelta, datetime
 from contextlib import contextmanager
-from mock import ANY
+from mock import ANY, patch, Mock
 from semantic_version import Version
 
 
@@ -683,6 +683,49 @@ class LoginTestCase(unittest.TestCase):
         expected_exception_message = 'REMEMBER_COOKIE_DURATION must be a ' \
             'datetime.timedelta, instead got: 123'
         self.assertIn(expected_exception_message, str(cm.exception))
+
+    def test_remember_me_refresh_every_request(self):
+        domain = self.app.config['REMEMBER_COOKIE_DOMAIN'] = '.localhost.local'
+        path = self.app.config['REMEMBER_COOKIE_PATH'] = '/'
+
+        # No refresh
+        self.app.config['REMEMBER_COOKIE_REFRESH_EACH_REQUEST'] = False
+        with self.app.test_client() as c:
+            c.get('/login-notch-remember')
+            self.assertIn('remember', c.cookie_jar._cookies[domain][path])
+            expiration_date_1 = datetime.utcfromtimestamp(
+                c.cookie_jar._cookies[domain][path]['remember'].expires)
+
+            self._delete_session(c)
+
+            c.get('/username')
+            self.assertIn('remember', c.cookie_jar._cookies[domain][path])
+            expiration_date_2 = datetime.utcfromtimestamp(
+                c.cookie_jar._cookies[domain][path]['remember'].expires)
+            self.assertEqual(expiration_date_1, expiration_date_2)
+
+        # With refresh (mock datetime's `utcnow`)
+        with patch('flask_login.login_manager.datetime') as mock_dt:
+            self.app.config['REMEMBER_COOKIE_REFRESH_EACH_REQUEST'] = True
+            now = datetime.utcnow()
+            mock_dt.utcnow = Mock(return_value=now)
+
+            with self.app.test_client() as c:
+                c.get('/login-notch-remember')
+                self.assertIn('remember', c.cookie_jar._cookies[domain][path])
+                expiration_date_1 = datetime.utcfromtimestamp(
+                    c.cookie_jar._cookies[domain][path]['remember'].expires)
+                self.assertIsNotNone(expiration_date_1)
+
+                self._delete_session(c)
+
+                mock_dt.utcnow = Mock(return_value=now + timedelta(seconds=1))
+                c.get('/username')
+                self.assertIn('remember', c.cookie_jar._cookies[domain][path])
+                expiration_date_2 = datetime.utcfromtimestamp(
+                    c.cookie_jar._cookies[domain][path]['remember'].expires)
+                self.assertIsNotNone(expiration_date_2)
+                self.assertNotEqual(expiration_date_1, expiration_date_2)
 
     def test_remember_me_is_unfresh(self):
         with self.app.test_client() as c:


### PR DESCRIPTION
Similar to Flask's `SESSION_REFRESH_EACH_REQUEST`, but for the remember
me cookie.

Off by default, can be turned on by setting the config parameter.
`REMEMBER_COOKIE_REFRESH_EACH_REQUEST` to `True`.