### PR TITLE
Add parameter 'duration' to login_user

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -290,7 +290,9 @@ after the user has logged out.
 makes it nearly transparent - just pass ``remember=True`` to the `login_user`
 call. A cookie will be saved on the user's computer, and then Flask-Login
 will automatically restore the user ID from that cookie if it is not in the
-session. The cookie is tamper-proof, so if the user tampers with it (i.e.
+session. The amount of time before the cookie expires can be set with the
+`REMEMBER_COOKIE_DURATION` configuration or it can be passed to `login_user`.
+The cookie is tamper-proof, so if the user tampers with it (i.e.
 inserts someone else's user ID in place of their own), the cookie will merely
 be rejected, as if it was not there.
 

--- a/flask_login/login_manager.py
+++ b/flask_login/login_manager.py
@@ -7,7 +7,7 @@
 
 
 import warnings
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from flask import (_request_ctx_stack, abort, current_app, flash, redirect,
                    request, session)
@@ -415,12 +415,16 @@ class LoginManager(object):
         # cookie settings
         config = current_app.config
         cookie_name = config.get('REMEMBER_COOKIE_NAME', COOKIE_NAME)
-        duration = config.get('REMEMBER_COOKIE_DURATION', COOKIE_DURATION)
         domain = config.get('REMEMBER_COOKIE_DOMAIN')
         path = config.get('REMEMBER_COOKIE_PATH', '/')
 
         secure = config.get('REMEMBER_COOKIE_SECURE', COOKIE_SECURE)
         httponly = config.get('REMEMBER_COOKIE_HTTPONLY', COOKIE_HTTPONLY)
+
+        if 'remember_seconds' in session:
+            duration = timedelta(seconds=session['remember_seconds'])
+        else:
+            duration = config.get('REMEMBER_COOKIE_DURATION', COOKIE_DURATION)
 
         # prepare data
         data = encode_cookie(text_type(session['user_id']))


### PR DESCRIPTION
Add the optional parameter 'duration' to the method login_user to define the duration of the 'remember me' cookie. The parameter receives a timedelta object, which is the same object used for the 'COOKIE_DURATION' configuration. 

It implements #105 