### PR TITLE
Simplify user loading

### DIFF
--- a/flask_login/login_manager.py
+++ b/flask_login/login_manager.py
@@ -21,7 +21,7 @@ from .mixins import AnonymousUserMixin
 from .signals import (user_loaded_from_cookie, user_loaded_from_header,
                       user_loaded_from_request, user_unauthorized,
                       user_needs_refresh, user_accessed, session_protected)
-from .utils import (_get_user, login_url as make_login_url, _create_identifier,
+from .utils import (login_url as make_login_url, _create_identifier,
                     _user_context_processor, encode_cookie, decode_cookie,
                     make_next_param, expand_login_view)
 
@@ -75,13 +75,13 @@ class LoginManager(object):
         #: and ``self.needs_refresh_message``
         self.localize_callback = None
 
-        self.user_callback = None
-
         self.unauthorized_callback = None
 
         self.needs_refresh_callback = None
 
         self.id_attribute = ID_ATTRIBUTE
+
+        self.user_callback = None
 
         self.header_callback = None
 
@@ -200,6 +200,8 @@ class LoginManager(object):
         :param callback: The callback for retrieving a user object.
         :type callback: callable
         '''
+        print('LoginManager.header_loader is deprecated. Use ' +
+              'LoginManager.request_loader instead.')
         self.header_callback = callback
         return callback
 
@@ -287,87 +289,63 @@ class LoginManager(object):
 
         return redirect(redirect_url)
 
-    def reload_user(self, user=None):
-        '''
-        This set the ctx.user with the user object loaded by your customized
-        user_loader callback function, which should retrieved the user object
-        with the user_id got from session.
+    def _update_request_context_with_user(self, user=None):
+        '''Store the given user as ctx.user.'''
 
-        Syntax example:
-        from flask_login import LoginManager
-        @login_manager.user_loader
-        def any_valid_func_name(user_id):
-            # get your user object using the given user_id,
-            # if you use SQLAlchemy, for example:
-            user_obj = User.query.get(int(user_id))
-            return user_obj
-
-        Reason to let YOU define this self.user_callback:
-            Because we won't know how/where you will load you user object.
-        '''
         ctx = _request_ctx_stack.top
-
-        if user is None:
-            user_id = session.get('user_id')
-            if user_id is None:
-                ctx.user = self.anonymous_user()
-            else:
-                if self.user_callback is None:
-                    raise Exception(
-                        "No user_loader has been installed for this "
-                        "LoginManager. Refer to "
-                        "https://flask-login.readthedocs.io/"
-                        "en/latest/#how-it-works for more info.")
-                user = self.user_callback(user_id)
-                if user is None:
-                    ctx.user = self.anonymous_user()
-                else:
-                    ctx.user = user
-        else:
-            ctx.user = user
+        ctx.user = self.anonymous_user() if user is None else user
 
     def _load_user(self):
         '''Loads user from session or remember_me cookie as applicable'''
+
+        if self.user_callback is None and self.request_callback is None:
+            raise Exception(
+                "Missing user_loader or request_loader. Refer to "
+                "http://flask-login.readthedocs.io/#how-it-works "
+                "for more info.")
+
         user_accessed.send(current_app._get_current_object())
 
-        # first check SESSION_PROTECTION
-        config = current_app.config
-        if config.get('SESSION_PROTECTION', self.session_protection):
-            deleted = self._session_protection()
-            if deleted:
-                return self.reload_user()
+        # Check SESSION_PROTECTION
+        if self._session_protection_failed():
+            return self._update_request_context_with_user()
 
-        # If a remember cookie is set, and the session is not, move the
-        # cookie user ID to the session.
-        #
-        # However, the session may have been set if the user has been
-        # logged out on this request, 'remember' would be set to clear,
-        # so we should check for that and not restore the session.
-        is_missing_user_id = 'user_id' not in session
-        if is_missing_user_id:
+        user = None
+
+        # Load user from Flask Session
+        user_id = session.get('user_id')
+        if user_id is not None and self.user_callback is not None:
+            user = self.user_callback(user_id)
+
+        # Load user from Remember Me Cookie or Request Loader
+        if user is None:
+            config = current_app.config
             cookie_name = config.get('REMEMBER_COOKIE_NAME', COOKIE_NAME)
             header_name = config.get('AUTH_HEADER_NAME', AUTH_HEADER_NAME)
             has_cookie = (cookie_name in request.cookies and
                           session.get('remember') != 'clear')
             if has_cookie:
-                return self._load_from_cookie(request.cookies[cookie_name])
+                cookie = request.cookies[cookie_name]
+                user = self._load_user_from_remember_cookie(cookie)
             elif self.request_callback:
-                return self._load_from_request(request)
+                user = self._load_user_from_request(request)
             elif header_name in request.headers:
-                return self._load_from_header(request.headers[header_name])
+                user = self._load_user_from_header(request.headers[header_name])
 
-        return self.reload_user()
+        return self._update_request_context_with_user(user)
 
-    def _session_protection(self):
+    def _session_protection_failed(self):
         sess = session._get_current_object()
         ident = self._session_identifier_generator()
 
         app = current_app._get_current_object()
         mode = app.config.get('SESSION_PROTECTION', self.session_protection)
 
+        if not mode or mode not in ['basic', 'strong']:
+            return False
+
         # if the sess is empty, it's an anonymous user or just logged out
         # so we can skip this
-
         if sess and ident != sess.get('_id', None):
             if mode == 'basic' or sess.permanent:
                 sess['_fresh'] = False
@@ -383,39 +361,37 @@ class LoginManager(object):
 
         return False
 
-    def _load_from_cookie(self, cookie):
+    def _load_user_from_remember_cookie(self, cookie):
         user_id = decode_cookie(cookie)
         if user_id is not None:
             session['user_id'] = user_id
             session['_fresh'] = False
+            user = None
+            if self.user_callback:
+                user = self.user_callback(user_id)
+            if user is not None:
+                app = current_app._get_current_object()
+                user_loaded_from_cookie.send(app, user=user)
+                return user
+        return None
 
-        self.reload_user()
-
-        if _request_ctx_stack.top.user is not None:
-            app = current_app._get_current_object()
-            user_loaded_from_cookie.send(app, user=_get_user())
-
-    def _load_from_header(self, header):
-        user = None
+    def _load_user_from_header(self, header):
         if self.header_callback:
             user = self.header_callback(header)
-        if user is not None:
-            self.reload_user(user=user)
-            app = current_app._get_current_object()
-            user_loaded_from_header.send(app, user=_get_user())
-        else:
-            self.reload_user()
+            if user is not None:
+                app = current_app._get_current_object()
+                user_loaded_from_header.send(app, user=user)
+                return user
+        return None
 
-    def _load_from_request(self, request):
-        user = None
+    def _load_user_from_request(self, request):
         if self.request_callback:
             user = self.request_callback(request)
-        if user is not None:
-            self.reload_user(user=user)
-            app = current_app._get_current_object()
-            user_loaded_from_request.send(app, user=_get_user())
-        else:
-            self.reload_user()
+            if user is not None:
+                app = current_app._get_current_object()
+                user_loaded_from_request.send(app, user=user)
+                return user
+        return None
 
     def _update_remember_cookie(self, response):
         # Don't modify the session unless there's something to do.

--- a/flask_login/login_manager.py
+++ b/flask_login/login_manager.py
@@ -330,7 +330,8 @@ class LoginManager(object):
             elif self._request_callback:
                 user = self._load_user_from_request(request)
             elif header_name in request.headers:
-                user = self._load_user_from_header(request.headers[header_name])
+                header = request.headers[header_name]
+                user = self._load_user_from_header(header)
 
         return self._update_request_context_with_user(user)
 

--- a/flask_login/login_manager.py
+++ b/flask_login/login_manager.py
@@ -81,11 +81,11 @@ class LoginManager(object):
 
         self.id_attribute = ID_ATTRIBUTE
 
-        self.user_callback = None
+        self._user_callback = None
 
-        self.header_callback = None
+        self._header_callback = None
 
-        self.request_callback = None
+        self._request_callback = None
 
         self._session_identifier_generator = _create_identifier
 
@@ -185,7 +185,7 @@ class LoginManager(object):
         :param callback: The callback for retrieving a user object.
         :type callback: callable
         '''
-        self.user_callback = callback
+        self._user_callback = callback
         return callback
 
     def header_loader(self, callback):
@@ -202,7 +202,7 @@ class LoginManager(object):
         '''
         print('LoginManager.header_loader is deprecated. Use ' +
               'LoginManager.request_loader instead.')
-        self.header_callback = callback
+        self._header_callback = callback
         return callback
 
     def request_loader(self, callback):
@@ -214,7 +214,7 @@ class LoginManager(object):
         :param callback: The callback for retrieving a user object.
         :type callback: callable
         '''
-        self.request_callback = callback
+        self._request_callback = callback
         return callback
 
     def unauthorized_handler(self, callback):
@@ -298,7 +298,7 @@ class LoginManager(object):
     def _load_user(self):
         '''Loads user from session or remember_me cookie as applicable'''
 
-        if self.user_callback is None and self.request_callback is None:
+        if self._user_callback is None and self._request_callback is None:
             raise Exception(
                 "Missing user_loader or request_loader. Refer to "
                 "http://flask-login.readthedocs.io/#how-it-works "
@@ -314,8 +314,8 @@ class LoginManager(object):
 
         # Load user from Flask Session
         user_id = session.get('user_id')
-        if user_id is not None and self.user_callback is not None:
-            user = self.user_callback(user_id)
+        if user_id is not None and self._user_callback is not None:
+            user = self._user_callback(user_id)
 
         # Load user from Remember Me Cookie or Request Loader
         if user is None:
@@ -327,7 +327,7 @@ class LoginManager(object):
             if has_cookie:
                 cookie = request.cookies[cookie_name]
                 user = self._load_user_from_remember_cookie(cookie)
-            elif self.request_callback:
+            elif self._request_callback:
                 user = self._load_user_from_request(request)
             elif header_name in request.headers:
                 user = self._load_user_from_header(request.headers[header_name])
@@ -367,8 +367,8 @@ class LoginManager(object):
             session['user_id'] = user_id
             session['_fresh'] = False
             user = None
-            if self.user_callback:
-                user = self.user_callback(user_id)
+            if self._user_callback:
+                user = self._user_callback(user_id)
             if user is not None:
                 app = current_app._get_current_object()
                 user_loaded_from_cookie.send(app, user=user)
@@ -376,8 +376,8 @@ class LoginManager(object):
         return None
 
     def _load_user_from_header(self, header):
-        if self.header_callback:
-            user = self.header_callback(header)
+        if self._header_callback:
+            user = self._header_callback(header)
             if user is not None:
                 app = current_app._get_current_object()
                 user_loaded_from_header.send(app, user=user)
@@ -385,8 +385,8 @@ class LoginManager(object):
         return None
 
     def _load_user_from_request(self, request):
-        if self.request_callback:
-            user = self.request_callback(request)
+        if self._request_callback:
+            user = self._request_callback(request)
             if user is not None:
                 app = current_app._get_current_object()
                 user_loaded_from_request.send(app, user=user)

--- a/flask_login/utils.py
+++ b/flask_login/utils.py
@@ -176,7 +176,7 @@ def login_user(user, remember=False, duration=None, force=False, fresh=True):
                 raise Exception('duration must be a datetime.timedelta, '
                                 'instead got: {0}'.format(duration))
 
-    _request_ctx_stack.top.user = user
+    current_app.login_manager._update_request_context_with_user(user)
     user_logged_in.send(current_app._get_current_object(), user=_get_user())
     return True
 
@@ -203,7 +203,7 @@ def logout_user():
 
     user_logged_out.send(current_app._get_current_object(), user=user)
 
-    current_app.login_manager.reload_user()
+    current_app.login_manager._update_request_context_with_user()
     return True
 
 

--- a/test_login.py
+++ b/test_login.py
@@ -194,9 +194,8 @@ class InitializationTestCase(unittest.TestCase):
             session['user_id'] = '2'
             with self.assertRaises(Exception) as cm:
                 login_manager._load_user()
-            expected_exception_message = 'Missing user_loader or request_loader'
-            self.assertTrue(
-                str(cm.exception).startswith(expected_exception_message))
+            expected_message = 'Missing user_loader or request_loader'
+            self.assertTrue(str(cm.exception).startswith(expected_message))
 
 
 class MethodViewLoginTestCase(unittest.TestCase):

--- a/test_login.py
+++ b/test_login.py
@@ -117,7 +117,7 @@ USERS = {1: notch, 2: steve, 3: creeper, u'佐藤': germanjapanese}
 
 
 class AboutTestCase(unittest.TestCase):
-    """Make sure we can get version and other info."""
+    '''Make sure we can get version and other info.'''
 
     def test_have_about_data(self):
         self.assertTrue(__title__ is not None)
@@ -141,6 +141,10 @@ class StaticTestCase(unittest.TestCase):
         lm = LoginManager()
         lm.init_app(app)
 
+        @lm.user_loader
+        def load_user(user_id):
+            return USERS[int(user_id)]
+
         with app.test_client() as c:
             c.get('/static/favicon.ico')
             self.assertTrue(current_user.is_anonymous)
@@ -151,6 +155,10 @@ class StaticTestCase(unittest.TestCase):
         app.secret_key = 'this is a temp key'
         lm = LoginManager()
         lm.init_app(app)
+
+        @lm.user_loader
+        def load_user(user_id):
+            return USERS[int(user_id)]
 
         with app.test_client() as c:
             with listen_to(user_accessed) as listener:
@@ -185,8 +193,8 @@ class InitializationTestCase(unittest.TestCase):
         with self.app.test_request_context():
             session['user_id'] = '2'
             with self.assertRaises(Exception) as cm:
-                login_manager.reload_user()
-            expected_exception_message = 'No user_loader has been installed'
+                login_manager._load_user()
+            expected_exception_message = 'Missing user_loader or request_loader'
             self.assertTrue(
                 str(cm.exception).startswith(expected_exception_message))
 
@@ -1244,6 +1252,117 @@ class LoginTestCase(unittest.TestCase):
         with self.app.test_request_context():
             _ucp = self.app.context_processor(_user_context_processor)
             self.assertIsInstance(_ucp()['current_user'], AnonymousUserMixin)
+
+
+class LoginViaRequestTestCase(unittest.TestCase):
+    ''' Tests for LoginManager.request_loader.'''
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.config['SECRET_KEY'] = 'deterministic'
+        self.app.config['SESSION_PROTECTION'] = None
+        self.remember_cookie_name = 'remember'
+        self.app.config['REMEMBER_COOKIE_NAME'] = self.remember_cookie_name
+        self.login_manager = LoginManager()
+        self.login_manager.init_app(self.app)
+        self.login_manager._login_disabled = False
+
+        @self.app.route('/')
+        def index():
+            return u'Welcome!'
+
+        @self.app.route('/login-notch')
+        def login_notch():
+            return unicode(login_user(notch))
+
+        @self.app.route('/username')
+        def username():
+            if current_user.is_authenticated:
+                return current_user.name
+            return u'Anonymous', 401
+
+        @self.app.route('/logout')
+        def logout():
+            return unicode(logout_user())
+
+        @self.login_manager.request_loader
+        def load_user_from_request(request):
+            user_id = request.args.get('user_id') or session.get('user_id')
+            try:
+                user_id = int(float(user_id))
+            except TypeError:
+                pass
+            return USERS.get(user_id)
+
+        # This will help us with the possibility of typoes in the tests. Now
+        # we shouldn't have to check each response to help us set up state
+        # (such as login pages) to make sure it worked: we will always
+        # get an exception raised (rather than return a 404 response)
+        @self.app.errorhandler(404)
+        def handle_404(e):
+            raise e
+
+        unittest.TestCase.setUp(self)
+
+    def test_has_no_user_loader_callback(self):
+        self.assertIsNone(self.login_manager.user_callback)
+
+    def test_request_context_users_are_anonymous(self):
+        with self.app.test_request_context():
+            self.assertTrue(current_user.is_anonymous)
+
+    def test_defaults_anonymous(self):
+        with self.app.test_client() as c:
+            result = c.get('/username')
+            self.assertEqual(result.status_code, 401)
+
+    def test_login_via_request(self):
+        user_id = 2
+        user_name = USERS[user_id].name
+        with self.app.test_client() as c:
+            url = '/username?user_id={user_id}'.format(user_id=user_id)
+            result = c.get(url)
+            self.assertEqual(user_name, result.data.decode('utf-8'))
+
+    def test_login_via_request_uses_cookie_when_already_logged_in(self):
+        user_id = 2
+        user_name = notch.name
+        with self.app.test_client() as c:
+            c.get('/login-notch')
+            url = '/username'
+            result = c.get(url)
+            self.assertEqual(user_name, result.data.decode('utf-8'))
+            url = '/username?user_id={user_id}'.format(user_id=user_id)
+            result = c.get(url)
+            self.assertEqual(u'Steve', result.data.decode('utf-8'))
+
+    def test_login_invalid_user_with_request(self):
+        user_id = 9000
+        with self.app.test_client() as c:
+            url = '/username?user_id={user_id}'.format(user_id=user_id)
+            result = c.get(url)
+            self.assertEqual(result.status_code, 401)
+
+    def test_login_invalid_user_with_request_when_already_logged_in(self):
+        user_id = 9000
+        with self.app.test_client() as c:
+            url = '/login-notch'
+            result = c.get(url)
+            self.assertEqual(u'True', result.data.decode('utf-8'))
+            url = '/username?user_id={user_id}'.format(user_id=user_id)
+            result = c.get(url)
+            self.assertEqual(result.status_code, 401)
+
+    def test_login_user_with_request_does_not_modify_session(self):
+        user_id = 2
+        user_name = USERS[user_id].name
+        with self.app.test_client() as c:
+            url = '/username?user_id={user_id}'.format(user_id=user_id)
+            result = c.get(url)
+            self.assertEqual(user_name, result.data.decode('utf-8'))
+            url = '/username'
+            result = c.get(url)
+            self.assertEqual(u'Anonymous', result.data.decode('utf-8'))
 
 
 class TestLoginUrlGeneration(unittest.TestCase):

--- a/test_login.py
+++ b/test_login.py
@@ -383,7 +383,7 @@ class LoginTestCase(unittest.TestCase):
     def test_login_user_with_header(self):
         user_id = 2
         user_name = USERS[user_id].name
-        self.login_manager.request_callback = None
+        self.login_manager._request_callback = None
         with self.app.test_client() as c:
             basic_fmt = 'Basic {0}'
             decoded = bytes.decode(base64.b64encode(str.encode(str(user_id))))
@@ -394,7 +394,7 @@ class LoginTestCase(unittest.TestCase):
     def test_login_invalid_user_with_header(self):
         user_id = 9000
         user_name = u'Anonymous'
-        self.login_manager.request_callback = None
+        self.login_manager._request_callback = None
         with self.app.test_client() as c:
             basic_fmt = 'Basic {0}'
             decoded = bytes.decode(base64.b64encode(str.encode(str(user_id))))
@@ -857,7 +857,7 @@ class LoginTestCase(unittest.TestCase):
     def test_user_loaded_from_header_fired(self):
         user_id = 1
         user_name = USERS[user_id].name
-        self.login_manager.request_callback = None
+        self.login_manager._request_callback = None
         with self.app.test_client() as c:
             with listen_to(user_loaded_from_header) as listener:
                 headers = [
@@ -1305,7 +1305,7 @@ class LoginViaRequestTestCase(unittest.TestCase):
         unittest.TestCase.setUp(self)
 
     def test_has_no_user_loader_callback(self):
-        self.assertIsNone(self.login_manager.user_callback)
+        self.assertIsNone(self.login_manager._user_callback)
 
     def test_request_context_users_are_anonymous(self):
         with self.app.test_request_context():

--- a/test_login.py
+++ b/test_login.py
@@ -325,10 +325,6 @@ class LoginTestCase(unittest.TestCase):
 
         unittest.TestCase.setUp(self)
 
-    def _get_remember_cookie(self, test_client):
-        our_cookies = test_client.cookie_jar._cookies['localhost.local']['/']
-        return our_cookies[self.remember_cookie_name]
-
     def _delete_session(self, c):
         # Helper method to cause the session to be deleted
         # as if the browser was closed. This will remove
@@ -1004,6 +1000,16 @@ class LoginTestCase(unittest.TestCase):
             # "after_request" handlers that call _update_remember_cookie.
             # Ensure that if nothing changed the session is not modified.
             self.assertFalse(session.modified)
+
+    def test_invalid_remember_cookie(self):
+        domain = self.app.config['REMEMBER_COOKIE_DOMAIN'] = '.localhost.local'
+        with self.app.test_client() as c:
+            c.get('/login-notch-remember')
+            with c.session_transaction() as sess:
+                sess['user_id'] = None
+            c.set_cookie(domain, self.remember_cookie_name, 'foo')
+            result = c.get('/username')
+            self.assertEqual(u'Anonymous', result.data.decode('utf-8'))
 
     #
     # Session Protection


### PR DESCRIPTION
This does a few things to simplify user loading:

* Only set user on current request context once in `LoginManager._load_user`
* Rename `LoginManager.reload_user` to `LoginManager._update_request_context_with_user`
* Stop loading user from session in `LoginManager._update_request_context_with_user`
* Load user from session in `LoginManager._load_user`
* Raise exception when loading user when both `user_loader` and `request_loader` undefined