### PR TITLE
Remove unused html_static_path from docs to avoid warning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,7 +129,7 @@ html_theme_path = ['_themes']
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
Otherwise I get
```
copying static files... WARNING: html_static_path entry '/var/tmp/portage/dev-python/flask-login-0.4.1/work/flask-login-0.4.1/docs/_static' does not exist                                                                                                                                 
```