### PR TITLE
Read login disabled from app config instead of storing on login manager

### DIFF
--- a/flask_login/login_manager.py
+++ b/flask_login/login_manager.py
@@ -10,7 +10,7 @@ import warnings
 from datetime import datetime, timedelta
 
 from flask import (_request_ctx_stack, abort, current_app, flash, redirect,
-                   request, session)
+                   has_app_context, request, session)
 
 from ._compat import text_type
 from .config import (COOKIE_NAME, COOKIE_DURATION, COOKIE_SECURE,
@@ -115,8 +115,6 @@ class LoginManager(object):
         '''
         app.login_manager = self
         app.after_request(self._update_remember_cookie)
-
-        self._login_disabled = app.config.get('LOGIN_DISABLED', False)
 
         if add_context_processor:
             app.context_processor(_user_context_processor)
@@ -455,3 +453,15 @@ class LoginManager(object):
         domain = config.get('REMEMBER_COOKIE_DOMAIN')
         path = config.get('REMEMBER_COOKIE_PATH', '/')
         response.delete_cookie(cookie_name, domain=domain, path=path)
+
+    @property
+    def _login_disabled(self):
+        """Legacy property, use app.config['LOGIN_DISABLED'] instead."""
+        if has_app_context():
+            return current_app.config.get('LOGIN_DISABLED', False)
+        return False
+
+    @_login_disabled.setter
+    def _login_disabled(self, newvalue):
+        """Legacy property setter, use app.config['LOGIN_DISABLED'] instead."""
+        current_app.config['LOGIN_DISABLED'] = newvalue

--- a/flask_login/utils.py
+++ b/flask_login/utils.py
@@ -257,7 +257,7 @@ def login_required(func):
     def decorated_view(*args, **kwargs):
         if request.method in EXEMPT_METHODS:
             return func(*args, **kwargs)
-        elif current_app.login_manager._login_disabled:
+        elif current_app.config.get('LOGIN_DISABLED'):
             return func(*args, **kwargs)
         elif not current_user.is_authenticated:
             return current_app.login_manager.unauthorized()
@@ -293,7 +293,7 @@ def fresh_login_required(func):
     def decorated_view(*args, **kwargs):
         if request.method in EXEMPT_METHODS:
             return func(*args, **kwargs)
-        elif current_app.login_manager._login_disabled:
+        elif current_app.config.get('LOGIN_DISABLED'):
             return func(*args, **kwargs)
         elif not current_user.is_authenticated:
             return current_app.login_manager.unauthorized()

--- a/test_login.py
+++ b/test_login.py
@@ -187,6 +187,9 @@ class InitializationTestCase(unittest.TestCase):
     def test_login_disabled_is_set(self):
         login_manager = LoginManager(self.app, add_context_processor=True)
         self.assertFalse(login_manager._login_disabled)
+        with self.app.app_context():
+            login_manager._login_disabled = True
+            self.assertTrue(login_manager._login_disabled)
 
     def test_no_user_loader_raises(self):
         login_manager = LoginManager(self.app, add_context_processor=True)
@@ -203,7 +206,7 @@ class MethodViewLoginTestCase(unittest.TestCase):
         self.app = Flask(__name__)
         self.login_manager = LoginManager()
         self.login_manager.init_app(self.app)
-        self.login_manager._login_disabled = False
+        self.app.config['LOGIN_DISABLED'] = False
 
         class SecretEndpoint(MethodView):
             decorators = [
@@ -237,7 +240,7 @@ class LoginTestCase(unittest.TestCase):
         self.app.config['REMEMBER_COOKIE_NAME'] = self.remember_cookie_name
         self.login_manager = LoginManager()
         self.login_manager.init_app(self.app)
-        self.login_manager._login_disabled = False
+        self.app.config['LOGIN_DISABLED'] = False
 
         @self.app.route('/')
         def index():
@@ -1224,7 +1227,7 @@ class LoginTestCase(unittest.TestCase):
         def protected():
             return u'Access Granted'
 
-        self.app.login_manager._login_disabled = True
+        self.app.config['LOGIN_DISABLED'] = True
 
         with self.app.test_client() as c:
             result = c.get('/protected')
@@ -1289,7 +1292,7 @@ class LoginViaRequestTestCase(unittest.TestCase):
         self.app.config['REMEMBER_COOKIE_NAME'] = self.remember_cookie_name
         self.login_manager = LoginManager()
         self.login_manager.init_app(self.app)
-        self.login_manager._login_disabled = False
+        self.app.config['LOGIN_DISABLED'] = False
 
         @self.app.route('/')
         def index():
@@ -1540,7 +1543,7 @@ class UnicodeCookieUserIDTestCase(unittest.TestCase):
         self.app.config['REMEMBER_COOKIE_NAME'] = self.remember_cookie_name
         self.login_manager = LoginManager()
         self.login_manager.init_app(self.app)
-        self.login_manager._login_disabled = False
+        self.app.config['LOGIN_DISABLED'] = False
 
         @self.app.route('/')
         def index():
@@ -1608,7 +1611,7 @@ class StrictHostForRedirectsTestCase(unittest.TestCase):
         self.app.config['REMEMBER_COOKIE_NAME'] = self.remember_cookie_name
         self.login_manager = LoginManager()
         self.login_manager.init_app(self.app)
-        self.login_manager._login_disabled = False
+        self.app.config['LOGIN_DISABLED'] = False
 
         @self.app.route('/secret')
         def secret():


### PR DESCRIPTION
Fixes #409.

Left `LoginManager._login_disabled` available as a legacy property, but it now only works within an app context.