### PR TITLE
Add support for an explicit key when calling encode_cookie() and decode_cookie()

### DIFF
--- a/flask_login/utils.py
+++ b/flask_login/utils.py
@@ -26,24 +26,32 @@ from .signals import user_logged_in, user_logged_out, user_login_confirmed
 current_user = LocalProxy(lambda: _get_user())
 
 
-def encode_cookie(payload):
+def encode_cookie(payload, key=None):
     '''
     This will encode a ``unicode`` value into a cookie, and sign that cookie
     with the app's secret key.
 
     :param payload: The value to encode, as `unicode`.
     :type payload: unicode
+
+    :param key: The key to use when creating the cookie digest. If not
+                specified, the SECRET_KEY value from app config will be used.
+    :type key: str
     '''
-    return u'{0}|{1}'.format(payload, _cookie_digest(payload))
+    return u'{0}|{1}'.format(payload, _cookie_digest(payload, key=key))
 
 
-def decode_cookie(cookie):
+def decode_cookie(cookie, key=None):
     '''
     This decodes a cookie given by `encode_cookie`. If verification of the
     cookie fails, ``None`` will be implicitly returned.
 
     :param cookie: An encoded cookie.
     :type cookie: str
+
+    :param key: The key to use when creating the cookie digest. If not
+                specified, the SECRET_KEY value from app config will be used.
+    :type key: str
     '''
     try:
         payload, digest = cookie.rsplit(u'|', 1)
@@ -52,7 +60,7 @@ def decode_cookie(cookie):
     except ValueError:
         return
 
-    if safe_str_cmp(_cookie_digest(payload), digest):
+    if safe_str_cmp(_cookie_digest(payload, key=key), digest):
         return payload
 
 

--- a/test_login.py
+++ b/test_login.py
@@ -1462,6 +1462,25 @@ class CookieEncodingTestCase(unittest.TestCase):
             self.assertIsNone(decode_cookie(u'Foo|BAD_BASH'))
             self.assertIsNone(decode_cookie(u'no bar'))
 
+    def test_cookie_encoding_with_key(self):
+        app = Flask(__name__)
+        app.config['SECRET_KEY'] = 'not-used'
+        key = 'deterministic'
+
+        # COOKIE = u'1|7d276051c1eec578ed86f6b8478f7f7d803a7970'
+
+        # Due to the restriction of 80 chars I have to break up the hash in two
+        h1 = u'0e9e6e9855fbe6df7906ec4737578a1d491b38d3fd5246c1561016e189d6516'
+        h2 = u'043286501ca43257c938e60aad77acec5ce916b94ca9d00c0bb6f9883ae4b82'
+        h3 = u'ae'
+        COOKIE = u'1|' + h1 + h2 + h3
+
+        with app.test_request_context():
+            self.assertEqual(COOKIE, encode_cookie(u'1', key=key))
+            self.assertEqual(u'1', decode_cookie(COOKIE, key=key))
+            self.assertIsNone(decode_cookie(u'Foo|BAD_BASH', key=key))
+            self.assertIsNone(decode_cookie(u'no bar', key=key))
+
 
 class SecretKeyTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
My organization uses blueprints to separate logical apps in our Flask app, creating blueprint-specific secret keys for cookie encoding.

We have been using some hackery to get `flask_login` working by overriding `utils._secret_key()`.  I was hoping that we could add support for an explicit key for cookie encoding here, as it would make our code much simpler and it seems like something that may be useful to others as well.

Please let me know if you have any questions or concerns.  Thanks!