### PR TITLE
Disable coveralls for Travis when env is Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - pypy3
 install:
   - python install_requirements.py dev
-  - travis_retry pip install coveralls
+  - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then travis_retry pip install coveralls; fi
 script: make check
 after_success:
-  - coveralls
+  - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then coveralls; fi


### PR DESCRIPTION
Coveralls removed support for Python 2.6, so only run coveralls on newer versions of Python.