### PR TITLE
Fix and improve documentation examples

### DIFF
--- a/flask_login/utils.py
+++ b/flask_login/utils.py
@@ -238,7 +238,7 @@ def login_required(func):
         @app.route('/post')
         @login_required
         def post():
-            pass
+            return a_response
 
     If there are only certain times you need to require that your user is
     logged in, you can do so with::


### PR DESCRIPTION
Addresses #349 

- Added required imports to code snippets
- Fixed `next` variable name shadowing built-in
- Fixed login example so that it actually redirects to the next page after login
- Added links to documentation on forms and flashing
- Made examples more consistent