### PR TITLE
Session Protection Documentation Clarification

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -423,7 +423,7 @@ generated will be stored. If it has an identifier, and it matches the one
 generated, then the request is OK.
 
 If the identifiers do not match in `basic` mode, or when the session is
-permanent, then the session will simply be marked as non-fresh, and anything
+permanent (and session protection is active), then the session will simply be marked as non-fresh, and anything
 requiring a fresh login will force the user to re-authenticate. (Of course,
 you must be already using fresh logins where appropriate for this to have an
 effect.)


### PR DESCRIPTION
Add clarification to session protection documentation.

Based on the current documentation you could interpret basic mode behavior as being whenever the session is permanent, even if the session protection is disabled. This PR just adds clarification that this only happens if session protection is truthy.

In pseudocode:

Wrong interpretation:
```
if (session_protection == 'basic or session.permanent = true) and not valid_identifier():
  session.fresh = false
```

Intended interpretation:

```
if session_protection and (session_protection == 'basic' or session.permanent == true) and not valid_identifier():
  session.fresh = false
```