### PR TITLE
test client: refer to get_id()

### DIFF
--- a/flask_login/test_client.py
+++ b/flask_login/test_client.py
@@ -15,5 +15,5 @@ class FlaskLoginClient(FlaskClient):
 
         if user:
             with self.session_transaction() as sess:
-                sess["user_id"] = user.id
+                sess["user_id"] = user.get_id()
                 sess["_fresh"] = fresh


### PR DESCRIPTION
I forgot that a user class doesn't necessarily need to have an `id` property -- it only needs to have a `get_id()` method.