### PR TITLE
docs: Point Flask Snippet URL to Wayback Machine

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,7 +135,7 @@ function.
 
             next = flask.request.args.get('next')
             # is_safe_url should check if the url is safe for redirects.
-            # See http://flask.pocoo.org/snippets/62/ for an example.
+            # See warning below for an example.
             if not is_safe_url(next):
                 return flask.abort(400)
 
@@ -633,5 +633,5 @@ signals in your code.
    the app.
 
 .. _Flask documentation on signals: http://flask.pocoo.org/docs/signals/
-.. _this Flask Snippet: http://flask.pocoo.org/snippets/62/
+.. _this Flask Snippet: https://web.archive.org/web/20190217035443/http://flask.pocoo.org/snippets/62/
 .. _Flask documentation on sessions: http://flask.pocoo.org/docs/quickstart/#sessions


### PR DESCRIPTION
Since the docs were written, the Flask project reworked their
infrastructure underneath what is now the Pallets Project. The snippets
part of their servers appear to have been lost and discarded. So, this
commit changes the link in the Flask-Login docs to point to the last
known good copy of the page in the Wayback Machine.