### PR TITLE
Set remember cookie defaults to match upstream

### DIFF
--- a/flask_login/config.py
+++ b/flask_login/config.py
@@ -15,7 +15,7 @@ COOKIE_NAME = 'remember_token'
 #: The default time before the "remember me" cookie expires (365 days).
 COOKIE_DURATION = timedelta(days=365)
 
-#: Whether the "remember me" cookie requires Secure; defaults to ``None``
+#: Whether the "remember me" cookie requires Secure; defaults to ``False``
 COOKIE_SECURE = False
 
 #: Whether the "remember me" cookie uses HttpOnly or not; defaults to ``False``

--- a/flask_login/config.py
+++ b/flask_login/config.py
@@ -18,8 +18,8 @@ COOKIE_DURATION = timedelta(days=365)
 #: Whether the "remember me" cookie requires Secure; defaults to ``False``
 COOKIE_SECURE = False
 
-#: Whether the "remember me" cookie uses HttpOnly or not; defaults to ``False``
-COOKIE_HTTPONLY = False
+#: Whether the "remember me" cookie uses HttpOnly or not; defaults to ``True``
+COOKIE_HTTPONLY = True
 
 #: The default flash message to display when users need to log in.
 LOGIN_MESSAGE = u'Please log in to access this page.'

--- a/flask_login/config.py
+++ b/flask_login/config.py
@@ -16,7 +16,7 @@ COOKIE_NAME = 'remember_token'
 COOKIE_DURATION = timedelta(days=365)
 
 #: Whether the "remember me" cookie requires Secure; defaults to ``None``
-COOKIE_SECURE = None
+COOKIE_SECURE = False
 
 #: Whether the "remember me" cookie uses HttpOnly or not; defaults to ``False``
 COOKIE_HTTPONLY = False


### PR DESCRIPTION
Change default to match Flask session cookie: https://flask.palletsprojects.com/en/1.1.x/config/#SESSION_COOKIE_HTTPONLY

Fixes #426 