### PR TITLE
Prefix internal session keys with underscore

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,8 @@ Here you can see the full list of changes between each Flask-Login release.
 
 Unreleased
 ----------
-nothing yet
+- Prefix authenticated user_id, remember, and remember_seconds in Flask Session
+  with underscores to prevent accidental usage in application code. #465
 
 Version 1.0.0
 -------------

--- a/flask_login/config.py
+++ b/flask_login/config.py
@@ -42,7 +42,14 @@ AUTH_HEADER_NAME = 'Authorization'
 
 #: A set of session keys that are populated by Flask-Login. Use this set to
 #: purge keys safely and accurately.
-SESSION_KEYS = set(['user_id', 'remember', '_id', '_fresh', 'next'])
+SESSION_KEYS = set([
+    '_user_id',
+    '_remember',
+    '_remember_seconds',
+    '_id',
+    '_fresh',
+    'next',
+])
 
 #: A set of HTTP methods which are exempt from `login_required` and
 #: `fresh_login_required`. By default, this is just ``OPTIONS``.

--- a/flask_login/test_client.py
+++ b/flask_login/test_client.py
@@ -15,5 +15,5 @@ class FlaskLoginClient(FlaskClient):
 
         if user:
             with self.session_transaction() as sess:
-                sess["user_id"] = user.get_id()
+                sess["_user_id"] = user.get_id()
                 sess["_fresh"] = fresh

--- a/flask_login/utils.py
+++ b/flask_login/utils.py
@@ -167,19 +167,19 @@ def login_user(user, remember=False, duration=None, force=False, fresh=True):
         return False
 
     user_id = getattr(user, current_app.login_manager.id_attribute)()
-    session['user_id'] = user_id
+    session['_user_id'] = user_id
     session['_fresh'] = fresh
     session['_id'] = current_app.login_manager._session_identifier_generator()
 
     if remember:
-        session['remember'] = 'set'
+        session['_remember'] = 'set'
         if duration is not None:
             try:
                 # equal to timedelta.total_seconds() but works with Python 2.6
-                session['remember_seconds'] = (duration.microseconds +
-                                               (duration.seconds +
-                                                duration.days * 24 * 3600) *
-                                               10**6) / 10.0**6
+                session['_remember_seconds'] = (duration.microseconds +
+                                                (duration.seconds +
+                                                 duration.days * 24 * 3600) *
+                                                10**6) / 10.0**6
             except AttributeError:
                 raise Exception('duration must be a datetime.timedelta, '
                                 'instead got: {0}'.format(duration))
@@ -197,8 +197,8 @@ def logout_user():
 
     user = _get_user()
 
-    if 'user_id' in session:
-        session.pop('user_id')
+    if '_user_id' in session:
+        session.pop('_user_id')
 
     if '_fresh' in session:
         session.pop('_fresh')
@@ -208,9 +208,9 @@ def logout_user():
 
     cookie_name = current_app.config.get('REMEMBER_COOKIE_NAME', COOKIE_NAME)
     if cookie_name in request.cookies:
-        session['remember'] = 'clear'
-        if 'remember_seconds' in session:
-            session.pop('remember_seconds')
+        session['_remember'] = 'clear'
+        if '_remember_seconds' in session:
+            session.pop('_remember_seconds')
 
     user_logged_out.send(current_app._get_current_object(), user=user)
 

--- a/test_login.py
+++ b/test_login.py
@@ -202,7 +202,7 @@ class InitializationTestCase(unittest.TestCase):
     def test_no_user_loader_raises(self):
         login_manager = LoginManager(self.app, add_context_processor=True)
         with self.app.test_request_context():
-            session['user_id'] = '2'
+            session['_user_id'] = '2'
             with self.assertRaises(Exception) as cm:
                 login_manager._load_user()
             expected_message = 'Missing user_loader or request_loader'
@@ -443,7 +443,7 @@ class LoginTestCase(unittest.TestCase):
     def test_logout_without_current_user(self):
         with self.app.test_request_context():
             login_user(notch)
-            del session['user_id']
+            del session['_user_id']
             with listen_to(user_logged_out) as listener:
                 logout_user()
                 listener.assert_heard_one(self.app, user=ANY)
@@ -783,7 +783,7 @@ class LoginTestCase(unittest.TestCase):
 
         with self.assertRaises(Exception) as cm:
             with self.app.test_request_context():
-                session['user_id'] = 2
+                session['_user_id'] = 2
                 self.login_manager._set_cookie(None)
 
         expected_exception_message = 'REMEMBER_COOKIE_DURATION must be a ' \
@@ -1036,7 +1036,7 @@ class LoginTestCase(unittest.TestCase):
         with self.app.test_client() as c:
             c.get('/login-notch-remember')
             with c.session_transaction() as sess:
-                sess['user_id'] = None
+                sess['_user_id'] = None
             c.set_cookie(domain, self.remember_cookie_name, 'foo')
             result = c.get('/username')
             self.assertEqual(u'Anonymous', result.data.decode('utf-8'))
@@ -1322,7 +1322,7 @@ class LoginViaRequestTestCase(unittest.TestCase):
 
         @self.login_manager.request_loader
         def load_user_from_request(request):
-            user_id = request.args.get('user_id') or session.get('user_id')
+            user_id = request.args.get('user_id') or session.get('_user_id')
             try:
                 user_id = int(float(user_id))
             except TypeError:


### PR DESCRIPTION
To prevent accidental usage in app code. Fixes #465.