### PR TITLE
Change to better describe `is_authenticated`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,9 +86,9 @@ The class that you use to represent users needs to implement these properties
 and methods:
 
 `is_authenticated`
-    This property should return `True` if the user is authenticated, i.e. they
-    have provided valid credentials. (Only authenticated users will fulfill
-    the criteria of `login_required`.)
+    This propery should, broadly, always return `True`. It is used to check if
+    a given user is annonymised or not, as opposed to whether they are
+    authenticated.
 
 `is_active`
     This property should return `True` if this is an active user - in addition


### PR DESCRIPTION
As per https://github.com/maxcountryman/flask-login/issues/475

The issue relates to this property not intuitively doing as it is named or as the documentation suggests!

Please do feel free to suggest alternative wording. The key point is that this property should always return `True` and therefore should not be relied on in other code to actual confirm if the user is authenticated in a given session.  