### PR TITLE
Add description for blueprint_login_views in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -541,7 +541,7 @@ Configuring Login
 
       This is similar to login_view, except it is used when working with blueprints. It is a 
       dictionary that can store multiple views to redirect to for different blueprints. The redirects
-      are listed in the form of key as the blueprint's name and value as the redirect route. 
+      are listed in the form of key as the blueprint's name and value as the redirect to route. 
       
    .. attribute:: login_message
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -325,7 +325,7 @@ Then the `~UserMixin.get_id` method of your User class would return the
 alternative id instead of the user's primary ID::
 
     def get_id(self):
-        return unicode(self.alternative_id)
+        return str(self.alternative_id)
 
 This way you are free to change the user's alternative id to a new randomly
 generated value when the user changes their password, which would ensure their

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -536,7 +536,13 @@ Configuring Login
       The name of the view to redirect to when the user needs to log in. (This
       can be an absolute URL as well, if your authentication machinery is
       external to your application.)
+   
+   .. attribute:: blueprint_login_views
 
+      This is similar to login_view, except it is used when working with blueprints. It is a 
+      dictionary that can store multiple views to redirect to for different blueprints. The redirects
+      are listed in the form of key as the blueprint's name and value as the redirect route. 
+      
    .. attribute:: login_message
 
       The message to flash when a user is redirected to the login page.


### PR DESCRIPTION
In the current documentation, there is no description about blueprint_login_views or how to set it through login_manager.