### PR TITLE
Better UserMixin.is_authenticated default implementation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,8 @@ Unreleased
 - Various documentation corrections #484, #482, #487, #534
 - Fix `from flask_login import *` behavior, although note that
  `import *` is not usually a good pattern in code. #485
+- `UserMixin.is_authenticated` will return whatever `is_active` returns
+  by default. This prevents inactive users from logging in. #486, #530
 
 Version 0.5.0
 -------------

--- a/flask_login/mixins.py
+++ b/flask_login/mixins.py
@@ -22,7 +22,7 @@ class UserMixin:
 
     @property
     def is_authenticated(self):
-        return True
+        return self.is_active
 
     @property
     def is_anonymous(self):

--- a/test_login.py
+++ b/test_login.py
@@ -1786,8 +1786,8 @@ class CustomTestClientTestCase(unittest.TestCase):
             self.assertEqual('True', is_fresh.data.decode('utf-8'))
 
     def test_fresh_login_arg_to_test_client(self):
-        with self.app.test_client(user=creeper, fresh_login=False) as c:
+        with self.app.test_client(user=notch, fresh_login=False) as c:
             username = c.get('/username')
-            self.assertEqual('Creeper', username.data.decode('utf-8'))
+            self.assertEqual('Notch', username.data.decode('utf-8'))
             is_fresh = c.get('/is-fresh')
             self.assertEqual('False', is_fresh.data.decode('utf-8'))


### PR DESCRIPTION
Everyone usually overrides [UserMixin.is_authenticated](https://flask-login.readthedocs.io/en/latest/_modules/flask_login/mixins.html#UserMixin) to check `self.is_active`, so let's just make that the default implementation.

Fixes #486.