### PR TITLE
Set HTTP response code to 401 when unauthorized (in example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ failures:
 ```python
 @login_manager.unauthorized_handler
 def unauthorized_handler():
-    return 'Unauthorized'
+    return 'Unauthorized', 401
 ```
 
 Complete documentation for Flask-Login is available on [ReadTheDocs](https://flask-login.readthedocs.io/en/latest/).


### PR DESCRIPTION
I wonder if this would be the more correct behaviour or not?