### PR TITLE
Problems with utils.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,6 @@ def request_loader(request):
 
     user = User()
     user.id = email
-
-    # DO NOT ever store passwords in plaintext and always compare password
-    # hashes using constant-time comparison!
-    user.is_authenticated = request.form['password'] == users[email]['password']
-
     return user
 ```
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -207,6 +207,16 @@ If you would like to customize the process further, decorate a function with
         # do stuff
         return a_response
 
+For example: You are using Flask Login with Flask Restful.
+In your API (blueprint named as api) you don't wanna redirect to login page but return Unauthorized status code .::
+
+    from flask import redirect, url_for, request
+    from http import HTTPStatus
+    @login_manager.unauthorized_handler
+    def unauthorized():
+        if request.blueprint == 'api':
+            abort(HTTPStatus.UNAUTHORIZED)
+        return redirect(url_for('site.login'))
 
 Login using Authorization header
 ================================

--- a/flask_login/config.py
+++ b/flask_login/config.py
@@ -15,11 +15,11 @@ COOKIE_NAME = 'remember_token'
 #: The default time before the "remember me" cookie expires (365 days).
 COOKIE_DURATION = timedelta(days=365)
 
-#: Whether the "remember me" cookie requires Secure; defaults to ``None``
-COOKIE_SECURE = None
+#: Whether the "remember me" cookie requires Secure; defaults to ``False``
+COOKIE_SECURE = False
 
-#: Whether the "remember me" cookie uses HttpOnly or not; defaults to ``False``
-COOKIE_HTTPONLY = False
+#: Whether the "remember me" cookie uses HttpOnly or not; defaults to ``True``
+COOKIE_HTTPONLY = True
 
 #: Whether the "remember me" cookie requires same origin; defaults to ``None``
 COOKIE_SAMESITE = None


### PR DESCRIPTION
When I want to check if the user is authenticated, I get a UnicodeEncodeError error because you are using latin-1 encoding on line 387 only I changed the encoding to utf-8 the error immediately disappeared.
It can appear in different places, for example when the user is not logged in or when he tries to log in. Here are my code examples.

decorators.py
```py
def is_auth(f):
	@wraps(f)
	def decorate_func(*args, **kwargs):
		if current_user.is_authenticated:
			return redirect(url_for('.index'))
		return f(*args, **kwargs)
	return decorate_func
```

views.py
```py
@main.route('/login/', methods=['post', 'get'])
@is_auth
def login():
	form = LoginForm()
	if form.validate_on_submit():
		user = find_data.find_user(email=form.email.data)
		if user and user.check_password(form.password.data):
			login_user(user, remember=form.remember.data)
			return redirect(url_for('.index'))
		else:
			flash("Invalid email/password", 'error')
			return redirect(url_for('.login'))

	return render_template('login.html', form=form)
```
Also your code 
flask_login/utils.py
```py
def _secret_key(key=None):
    if key is None:
        key = current_app.config['SECRET_KEY']

    if isinstance(key, text_type):  # pragma: no cover
        key = key.encode('latin-1')  # ensure bytes

    return key
``` 

HERE i have problems when key.encode('latin-1')	
But you need to change the encoding only to utf-8 as the error disappears immediately  key.encode('utf-8')	
Video https://www.youtube.com/watch?v=9yzESWko_7o&ab_channel=%D0%93%D0%BE%D0%BB%D0%BE%D0%B2%D0%B0%D1%86%D1%8C%D0%BA%D0%B8%D0%B9%D0%AF%D1%80%D0%BE%D1%81%D0%BB%D0%B0%D0%B2


