### PR TITLE
basic session protection: only set _fresh when needed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ Unreleased
  `import *` is not usually a good pattern in code. #485
 - `UserMixin.is_authenticated` will return whatever `is_active` returns
   by default. This prevents inactive users from logging in. #486, #530
+- Session protection will only mark the session as not fresh if it's not
+  already marked as such, avoiding modifying the session cookie
+  unnecessarily. #612
 
 Version 0.5.0
 -------------

--- a/src/flask_login/login_manager.py
+++ b/src/flask_login/login_manager.py
@@ -387,7 +387,8 @@ class LoginManager:
         # so we can skip this
         if sess and ident != sess.get("_id", None):
             if mode == "basic" or sess.permanent:
-                sess["_fresh"] = False
+                if sess.get("_fresh") is not False:
+                    sess["_fresh"] = False
                 session_protected.send(app)
                 return False
             elif mode == "strong":

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1806,3 +1806,9 @@ class CustomTestClientTestCase(unittest.TestCase):
             self.assertEqual("Notch", username.data.decode("utf-8"))
             is_fresh = c.get("/is-fresh")
             self.assertEqual("False", is_fresh.data.decode("utf-8"))
+
+    def test_not_fresh_not_modified(self):
+        self.app.config["SESSION_PROTECTION"] = "basic"
+        c = self.app.test_client(user=steve, fresh_login=False)
+        r = c.get("/username")
+        assert "Set-Cookie" not in r.headers


### PR DESCRIPTION
Only set _fresh to False if not already set. This prevents tripping session.modified, which forces a new session cookie to be sent with the response.

Only a minor annoyance, but after a useragent/ip change, if using basic session protection, every response will include a new session cookie if current_user is accessed.

edit: Or _id could be updated to prevent tripping session protection again until the next change.

closes #612 