### PR TITLE
Logout the not is_active user

### DIFF
--- a/flask_login/utils.py
+++ b/flask_login/utils.py
@@ -270,6 +270,9 @@ def login_required(func):
             pass
         elif not current_user.is_authenticated:
             return current_app.login_manager.unauthorized()
+        elif not current_user.is_active:
+            logout_user()
+            return current_app.login_manager.unauthorized()
         try:
             # current_app.ensure_sync available in Flask >= 2.0
             return current_app.ensure_sync(func)(*args, **kwargs)
@@ -311,6 +314,9 @@ def fresh_login_required(func):
             return current_app.login_manager.unauthorized()
         elif not login_fresh():
             return current_app.login_manager.needs_refresh()
+        elif not current_user.is_active:
+            logout_user()
+            return current_app.login_manager.unauthorized()
         try:
             # current_app.ensure_sync available in Flask >= 2.0
             return current_app.ensure_sync(func)(*args, **kwargs)


### PR DESCRIPTION
If the is_active value changes after a user has logged in, that user can continue to browse the site because he has logged in before. To prevent this, the user's is_active value can be checked in the login_required control.