### PR TITLE
improve readability of anonymous users properties

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -287,7 +287,8 @@ Anonymous Users
 By default, when a user is not actually logged in, `current_user` is set to
 an `AnonymousUserMixin` object. It has the following properties and methods:
 
-- `is_active` and `is_authenticated` are `False`
+- `is_active` is `False`
+- `is_authenticated` is `False`
 - `is_anonymous` is `True`
 - `get_id()` returns `None`
 


### PR DESCRIPTION
I updated the section on anonymous users so all default properties are on their own line. This decreases the chance of missing one of them accidentally.