### PR TITLE
get tests working with latest flask/werkzeug

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 
 blinker==1.4
 coverage==5.5
-flask[async]==2.0.1; python_version >= '3.7'
+flask[async]==2.1.0; python_version >= '3.7'
 pytest==6.1.2; python_version == '3.5'
 pytest==6.2.4; python_version > '3.5'
 pycodestyle==2.7.0


### PR DESCRIPTION
I'll get actual pinning for the test env next, wanted to get the tests updated to be compatible first.