### PR TITLE
fix `from flask_login import *`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,8 @@ Unreleased
 - Document `REMEMBER_COOKIE_SAMESITE` config #577
 - Revise setup.py to use README.md for long description #598
 - Various documentation corrections #484, #482, #487, #534
+- Fix `from flask_login import *` behavior, although note that
+ `import *` is not usually a good pattern in code. #485
 
 Version 0.5.0
 -------------

--- a/flask_login/__init__.py
+++ b/flask_login/__init__.py
@@ -27,11 +27,11 @@ from .utils import (current_user, login_url, login_fresh, login_user,
 
 
 __all__ = [
-    LoginManager.__name__,
-    FlaskLoginClient.__name__,
-    UserMixin.__name__,
-    AnonymousUserMixin.__name__,
-    __version__,
+    'LoginManager',
+    'FlaskLoginClient',
+    'UserMixin',
+    'AnonymousUserMixin',
+    '__version__',
     'COOKIE_NAME',
     'COOKIE_DURATION',
     'COOKIE_SECURE',


### PR DESCRIPTION
`__all__` should only contain strings with importable names. fixes #485 