### PR TITLE
lock old threads

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -1,0 +1,17 @@
+name: 'Lock threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3
+        with:
+          github-token: ${{ github.token }}
+          issue-inactive-days: 14
+          pr-inactive-days: 14
+          issue-lock-reason: ''
+          pr-lock-reason: ''


### PR DESCRIPTION
This workflow runs daily and locks any closed issues and PRs that have not had any activity in the last 14 days.

This has been very helpful in other projects to limit "drive by reporting" where users will resurrect closed issues with new comments rather than opening a new issue.

Recently, many stale issues were closed due to limited maintainer availability. If you come across an issue that was closed without discussion, and you still feel it is an issue, please open a new issue. Given the lack of maintainer availability, consider submitting a PR as well if the issue is important to you.