### PR TITLE
docs: Add note on where to find available configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ def unauthorized_handler():
 ```
 
 Documentation for Flask-Login is available on [ReadTheDocs](https://flask-login.readthedocs.io/en/latest/).
-For complete understanding of available configuration, please refer to the source code.
+For complete understanding of available configuration, please refer to the [source code](https://github.com/maxcountryman/flask-login).
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ def unauthorized_handler():
     return 'Unauthorized', 401
 ```
 
-Complete documentation for Flask-Login is available on [ReadTheDocs](https://flask-login.readthedocs.io/en/latest/).
+Documentation for Flask-Login is available on [ReadTheDocs](https://flask-login.readthedocs.io/en/latest/).
+For complete understanding of available configuration, please refer to the source code.
 
 
 ## Contributing

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,9 @@ to see how to set a secret key.
 "How to generate good secret keys" section to generate your own secret key.
 DO NOT use the example one.
 
+For a complete understanding of available configuration keys, please refer to
+the `source code`_.
+
 How it Works
 ============
 You will need to provide a `~LoginManager.user_loader` callback. This callback
@@ -658,6 +661,7 @@ signals in your code.
    marked non-fresh or deleted. It receives no additional arguments besides
    the app.
 
+.. _source code: https://github.com/maxcountryman/flask-login/tree/main/src/flask_login
 .. _Flask documentation on signals: http://flask.pocoo.org/docs/signals/
 .. _this Flask Snippet: https://web.archive.org/web/20120517003641/http://flask.pocoo.org/snippets/62/
 .. _Flask documentation on sessions: http://flask.pocoo.org/docs/quickstart/#sessions


### PR DESCRIPTION
Re #656.

Addresses misunderstanding that more configuration than is explicitly mentioned in docs exists.

As some keys may collide with other flask modules, such misunderstanding has potential for unexpected behavior and therefore security issues. This will at least highlight that further config exists and that the responsibility falls on the user.