### PR TITLE
Clean up docs and tests after merging `login_remembered()`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -508,12 +508,8 @@ logged in with this user!
             # this request has user 1 already logged in!
             resp = client.get("/")
 
-Other supported keyword arguments are:
-
-- ``fresh_login`` (``bool``, default ``True``): whether the current login is
-  fresh
-- ``remembered_login`` (``bool``, default ``False``): whether the current login
-  is remembered across sessions
+You may also pass ``fresh_login`` (``bool``, defaults to ``True``) to mark the
+current login as fresh or non-fresh.
 
 Note that you must use keyword arguments, not positional arguments. E.g.
 ``test_client(user=user)`` will work, but ``test_client(user)``


### PR DESCRIPTION
With the alternative implementation for the utility function `login_remembered()` in #654 merged, there are some inconsistencies in documentation and tests:

- The `remembered_login` option to the `FlaskLoginClient` was never merged and as such may be removed from the documentation.
- Tests for the 'remember me' flag are related to user login functionality and as such belong to the `LoginTestCase` rather than the `CustomTestClientTestCase`.

This patch resolves these inconsistencies.