### PR TITLE
remove previously deprecated code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Version 0.7.0
 
 Unreleased
 
+- Remove previously deprecated code. #694
+
 Version 0.6.2
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,13 +9,11 @@ extended periods of time.
 
 It will:
 
-- Store the active user's ID in the session, and let you log them in and out
-  easily.
-- Let you restrict views to logged-in (or logged-out) users.
+- Store the active user's ID in the `Flask Session`_, and let you easily log
+  them in and out.
+- Let you restrict views to logged-in (or logged-out) users. (`login_required`)
 - Handle the normally-tricky "remember me" functionality.
 - Help protect your users' sessions from being stolen by cookie thieves.
-- Possibly integrate with Flask-Principal or other authorization extensions
-  later on.
 
 However, it does not:
 
@@ -220,32 +218,6 @@ In your API (blueprint named as api) you don't wanna redirect to login page but 
         if request.blueprint == 'api':
             abort(HTTPStatus.UNAUTHORIZED)
         return redirect(url_for('site.login'))
-
-Login using Authorization header
-================================
-
-.. Caution::
-   This method will be deprecated; use the `~LoginManager.request_loader`
-   below instead.
-
-Sometimes you want to support Basic Auth login using the `Authorization`
-header, such as for api requests. To support login via header you will need
-to provide a `~LoginManager.header_loader` callback. This callback should behave
-the same as your `~LoginManager.user_loader` callback, except that it accepts
-a header value instead of a user id. For example::
-
-    @login_manager.header_loader
-    def load_user_from_header(header_val):
-        header_val = header_val.replace('Basic ', '', 1)
-        try:
-            header_val = base64.b64decode(header_val)
-        except TypeError:
-            pass
-        return User.query.filter_by(api_key=header_val).first()
-
-By default the `Authorization` header's value is passed to your
-`~LoginManager.header_loader` callback. You can change the header used with
-the `AUTH_HEADER_NAME` configuration.
 
 
 Custom Login using Request Loader
@@ -673,6 +645,7 @@ signals in your code.
    the app.
 
 .. _source code: https://github.com/maxcountryman/flask-login/tree/main/src/flask_login
-.. _Flask documentation on signals: http://flask.pocoo.org/docs/signals/
+.. _Flask documentation on signals: https://flask.palletsprojects.com/en/2.1.x/signals/
 .. _this Flask Snippet: https://web.archive.org/web/20120517003641/http://flask.pocoo.org/snippets/62/
-.. _Flask documentation on sessions: http://flask.pocoo.org/docs/quickstart/#sessions
+.. _Flask Session: https://flask.palletsprojects.com/en/2.1.x/api/#sessions
+.. _Flask documentation on sessions: https://flask.palletsprojects.com/en/2.1.x/quickstart/#sessions

--- a/src/flask_login/__init__.py
+++ b/src/flask_login/__init__.py
@@ -1,5 +1,4 @@
 from .__about__ import __version__
-from .config import AUTH_HEADER_NAME
 from .config import COOKIE_DURATION
 from .config import COOKIE_HTTPONLY
 from .config import COOKIE_NAME
@@ -38,7 +37,6 @@ from .utils import set_login_view
 
 __all__ = [
     "__version__",
-    "AUTH_HEADER_NAME",
     "COOKIE_DURATION",
     "COOKIE_HTTPONLY",
     "COOKIE_NAME",
@@ -75,20 +73,3 @@ __all__ = [
     "make_next_param",
     "set_login_view",
 ]
-
-
-def __getattr__(name):
-    if name == "user_loaded_from_header":
-        import warnings
-        from .signals import _user_loaded_from_header
-
-        warnings.warn(
-            "'user_loaded_from_header' is deprecated and will be"
-            " removed in Flask-Login 0.7. Use"
-            " 'user_loaded_from_request' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return _user_loaded_from_header
-
-    raise AttributeError(name)

--- a/src/flask_login/config.py
+++ b/src/flask_login/config.py
@@ -31,9 +31,6 @@ REFRESH_MESSAGE_CATEGORY = "message"
 #: The default attribute to retreive the str id of the user
 ID_ATTRIBUTE = "get_id"
 
-#: Default name of the auth header (``Authorization``)
-AUTH_HEADER_NAME = "Authorization"
-
 #: A set of session keys that are populated by Flask-Login. Use this set to
 #: purge keys safely and accurately.
 SESSION_KEYS = {

--- a/src/flask_login/signals.py
+++ b/src/flask_login/signals.py
@@ -14,10 +14,6 @@ user_logged_out = _signals.signal("logged-out")
 #: is the sender), it is passed `user`, which is the user being reloaded.
 user_loaded_from_cookie = _signals.signal("loaded-from-cookie")
 
-#: Sent when the user is loaded from the header. In addition to the app (which
-#: is the #: sender), it is passed `user`, which is the user being reloaded.
-_user_loaded_from_header = _signals.signal("loaded-from-header")
-
 #: Sent when the user is loaded from the request. In addition to the app (which
 #: is the #: sender), it is passed `user`, which is the user being reloaded.
 user_loaded_from_request = _signals.signal("loaded-from-request")
@@ -43,19 +39,3 @@ user_accessed = _signals.signal("accessed")
 #: marked non-fresh or deleted. It receives no additional arguments besides
 #: the app.
 session_protected = _signals.signal("session-protected")
-
-
-def __getattr__(name):
-    if name == "user_loaded_from_header":
-        import warnings
-
-        warnings.warn(
-            "'user_loaded_from_header' is deprecated and will be"
-            " removed in Flask-Login 0.7. Use"
-            " 'user_loaded_from_request' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return _user_loaded_from_header
-
-    raise AttributeError(name)


### PR DESCRIPTION
To get ready for a new feature release as per [this comment](https://github.com/maxcountryman/flask-login/discussions/670#discussioncomment-2768626).

* `header_loader`
* `user_loaded_from_header`
* `setup_app`
* `_login_disabled`