### PR TITLE
Clear the session data on login by default. Added support for an allow-list of session keys to preserve.

### DIFF
--- a/src/flask_login/config.py
+++ b/src/flask_login/config.py
@@ -45,6 +45,12 @@ SESSION_KEYS = {
     "next",
 }
 
+#: A set of session keys that should not be purged from the session when
+#: `login_user` is called. Use this set to preseve specific values in the
+#: session between unauthenticated and authenticated states. By default, the
+#: session data is cleared on login.
+PRESERVED_SESSION_KEYS = set()
+
 #: A set of HTTP methods which are exempt from `login_required` and
 #: `fresh_login_required`. By default, this is just ``OPTIONS``.
 EXEMPT_METHODS = {"OPTIONS"}

--- a/src/flask_login/utils.py
+++ b/src/flask_login/utils.py
@@ -18,6 +18,7 @@ from werkzeug.urls import url_encode
 from .config import COOKIE_NAME
 from .config import EXEMPT_METHODS
 from .config import PRESERVED_SESSION_KEYS
+from .config import SESSION_KEYS
 from .signals import user_logged_in
 from .signals import user_logged_out
 from .signals import user_login_confirmed
@@ -431,6 +432,10 @@ def _secret_key(key=None):
 
 
 def _clear_session():
-    preserved_keys = current_app.config.get("PRESERVED_SESSION_KEYS", PRESERVED_SESSION_KEYS)
-    for key in set(session.keys()).difference(preserved_keys):
+    preserved_keys = current_app.config.get(
+        "PRESERVED_SESSION_KEYS", PRESERVED_SESSION_KEYS
+    )
+    for key in set(session.keys()).difference(
+        SESSION_KEYS | preserved_keys | {"_permanent"}
+    ):
         del session[key]

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1154,6 +1154,7 @@ class LoginTestCase(unittest.TestCase):
 
     def test_session_protection_strong_deletes_session(self):
         self.app.config["SESSION_PROTECTION"] = "strong"
+        self.app.config["PRESERVED_SESSION_KEYS"] = {"foo"}
         with self.app.test_client() as c:
             # write some unrelated data in the session, to ensure it does not
             # get destroyed


### PR DESCRIPTION
Added a new configuration option `PRESERVED_SESSION_KEYS` to preserve specific values in the session between unauthenticated and authenticated states. By default, unrelated session data is cleared on login.

As privately reported to @maxcountryman and @davidism, this proposed change improves the security of Flask-Login when used in combination with CSRF protection libraries such as [Flask-WTF](https://github.com/wtforms/flask-wtf/). The patch ensures that CSRF tokens issued before login are invalidated after the user performs a successful authentication, eliminating the risk of CSRF token fixation attacks.

This PR was submitted publicly as requested by the project maintainer.