### PR TITLE
compatibility with Werkzeug 2.2 and Flask 2.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Version 0.6.2
 
 Unreleased
 
+- Fix compatibility with Werkzeug 2.2 and Flask 2.2. #691
 - Revert change to `expand_login_view` that attempted to preserve a
   dynamic subdomain value. Such values should be handled using
   `app.url_value_preprocessor` and `app.url_defaults`. #691

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 Flask-Login Changelog
 =====================
 
+Version 0.6.2
+-------------
+
+Unreleased
+
+- Revert change to `expand_login_view` that attempted to preserve a
+  dynamic subdomain value. Such values should be handled using
+  `app.url_value_preprocessor` and `app.url_defaults`. #691
+
 Version 0.6.1
 -------------
 

--- a/src/flask_login/login_manager.py
+++ b/src/flask_login/login_manager.py
@@ -2,10 +2,10 @@ import warnings
 from datetime import datetime
 from datetime import timedelta
 
-from flask import _request_ctx_stack
 from flask import abort
 from flask import current_app
 from flask import flash
+from flask import g
 from flask import has_app_context
 from flask import redirect
 from flask import request
@@ -328,8 +328,10 @@ class LoginManager:
     def _update_request_context_with_user(self, user=None):
         """Store the given user as ctx.user."""
 
-        ctx = _request_ctx_stack.top
-        ctx.user = self.anonymous_user() if user is None else user
+        if user is None:
+            user = self.anonymous_user()
+
+        g._login_user = user
 
     def _load_user(self):
         """Loads user from session or remember_me cookie as applicable"""

--- a/src/flask_login/utils.py
+++ b/src/flask_login/utils.py
@@ -4,8 +4,8 @@ from hashlib import sha512
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
 
-from flask import _request_ctx_stack
 from flask import current_app
+from flask import g
 from flask import has_request_context
 from flask import request
 from flask import session
@@ -367,10 +367,13 @@ def set_login_view(login_view, blueprint=None):
 
 
 def _get_user():
-    if has_request_context() and not hasattr(_request_ctx_stack.top, "user"):
-        current_app.login_manager._load_user()
+    if has_request_context():
+        if "_login_user" not in g:
+            current_app.login_manager._load_user()
 
-    return getattr(_request_ctx_stack.top, "user", None)
+        return g._login_user
+
+    return None
 
 
 def _cookie_digest(payload, key=None):

--- a/src/flask_login/utils.py
+++ b/src/flask_login/utils.py
@@ -11,7 +11,6 @@ from flask import request
 from flask import session
 from flask import url_for
 from werkzeug.local import LocalProxy
-from werkzeug.routing import parse_rule
 from werkzeug.urls import url_decode
 from werkzeug.urls import url_encode
 
@@ -94,20 +93,8 @@ def expand_login_view(login_view):
     """
     if login_view.startswith(("https://", "http://", "/")):
         return login_view
-    else:
-        try:
-            url_rule = request.url_rule.subdomain or request.url_rule.host
-        except AttributeError:
-            url_rule = None
-        if request.view_args and url_rule:
-            args = {}
-            for _, _, key in parse_rule(url_rule):
-                if not key or key not in request.view_args:
-                    continue
-                args[key] = request.view_args[key]
-            return url_for(login_view, **args)
-        else:
-            return url_for(login_view)
+
+    return url_for(login_view)
 
 
 def login_url(login_view, next_url=None, next_field="next"):


### PR DESCRIPTION
* Revert #462 and #663. Dynamic domain values should be managed with `app.url_value_preprocessor` and `app.url_defaults`, not by trying to re-parse the rule on every build.
  fixes #686 
* Store the user on `g._login_user` instead of `_app_ctx_stack.top.user`.
  fixes #690 