### PR TITLE
ensure deprecation warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,12 @@ Unreleased
 - Revert change to `expand_login_view` that attempted to preserve a
   dynamic subdomain value. Such values should be handled using
   `app.url_value_preprocessor` and `app.url_defaults`. #691
+- Ensure deprecation warnings are present for deprecated features that
+  will be removed in the next feature release.
+  - Use `request_loader` instead of `header_loader`.
+  - Use `user_loaded_from_request` instead of `user_loaded_from_header`.
+  - Use `app.config["LOGIN_DISABLED"]` instead of `_login_disabled`.
+  - Use `init_app` instead of `setup_app`.
 
 Version 0.6.1
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -543,7 +543,7 @@ Configuring Login
 
 .. autoclass:: LoginManager
 
-   .. automethod:: setup_app
+   .. automethod:: init_app
 
    .. automethod:: unauthorized
 
@@ -553,7 +553,7 @@ Configuring Login
 
    .. automethod:: user_loader
 
-   .. automethod:: header_loader
+   .. automethod:: request_loader
 
    .. attribute:: anonymous_user
 

--- a/src/flask_login/__init__.py
+++ b/src/flask_login/__init__.py
@@ -15,7 +15,6 @@ from .mixins import UserMixin
 from .signals import session_protected
 from .signals import user_accessed
 from .signals import user_loaded_from_cookie
-from .signals import user_loaded_from_header
 from .signals import user_loaded_from_request
 from .signals import user_logged_in
 from .signals import user_logged_out
@@ -55,7 +54,6 @@ __all__ = [
     "session_protected",
     "user_accessed",
     "user_loaded_from_cookie",
-    "user_loaded_from_header",
     "user_loaded_from_request",
     "user_logged_in",
     "user_logged_out",
@@ -77,3 +75,20 @@ __all__ = [
     "make_next_param",
     "set_login_view",
 ]
+
+
+def __getattr__(name):
+    if name == "user_loaded_from_header":
+        import warnings
+        from .signals import _user_loaded_from_header
+
+        warnings.warn(
+            "'user_loaded_from_header' is deprecated and will be"
+            " removed in Flask-Login 0.7. Use"
+            " 'user_loaded_from_request' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _user_loaded_from_header
+
+    raise AttributeError(name)

--- a/src/flask_login/login_manager.py
+++ b/src/flask_login/login_manager.py
@@ -1,4 +1,3 @@
-import warnings
 from datetime import datetime
 from datetime import timedelta
 
@@ -28,7 +27,6 @@ from .mixins import AnonymousUserMixin
 from .signals import session_protected
 from .signals import user_accessed
 from .signals import user_loaded_from_cookie
-from .signals import user_loaded_from_header
 from .signals import user_loaded_from_request
 from .signals import user_needs_refresh
 from .signals import user_unauthorized
@@ -113,8 +111,13 @@ class LoginManager:
         This method has been deprecated. Please use
         :meth:`LoginManager.init_app` instead.
         """
+        import warnings
+
         warnings.warn(
-            "Warning setup_app is deprecated. Please use init_app.", DeprecationWarning
+            "'setup_app' is deprecated and will be removed in"
+            " Flask-Login 0.7. Use 'init_app' instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
         self.init_app(app, add_context_processor)
 
@@ -318,9 +321,13 @@ class LoginManager:
         :param callback: The callback for retrieving a user object.
         :type callback: callable
         """
-        print(
-            "LoginManager.header_loader is deprecated. Use"
-            " LoginManager.request_loader instead."
+        import warnings
+
+        warnings.warn(
+            "'header_loader' is deprecated and will be removed in"
+            " Flask-Login 0.7. Use 'request_loader' instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
         self._header_callback = callback
         return callback
@@ -422,7 +429,10 @@ class LoginManager:
             user = self._header_callback(header)
             if user is not None:
                 app = current_app._get_current_object()
-                user_loaded_from_header.send(app, user=user)
+
+                from .signals import _user_loaded_from_header
+
+                _user_loaded_from_header.send(app, user=user)
                 return user
         return None
 
@@ -504,6 +514,16 @@ class LoginManager:
     @property
     def _login_disabled(self):
         """Legacy property, use app.config['LOGIN_DISABLED'] instead."""
+        import warnings
+
+        warnings.warn(
+            "'_login_disabled' is deprecated and will be removed in"
+            " Flask-Login 0.7. Use 'LOGIN_DISABLED' in 'app.config'"
+            " instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if has_app_context():
             return current_app.config.get("LOGIN_DISABLED", False)
         return False
@@ -511,4 +531,13 @@ class LoginManager:
     @_login_disabled.setter
     def _login_disabled(self, newvalue):
         """Legacy property setter, use app.config['LOGIN_DISABLED'] instead."""
+        import warnings
+
+        warnings.warn(
+            "'_login_disabled' is deprecated and will be removed in"
+            " Flask-Login 0.7. Use 'LOGIN_DISABLED' in 'app.config'"
+            " instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         current_app.config["LOGIN_DISABLED"] = newvalue

--- a/src/flask_login/signals.py
+++ b/src/flask_login/signals.py
@@ -16,7 +16,7 @@ user_loaded_from_cookie = _signals.signal("loaded-from-cookie")
 
 #: Sent when the user is loaded from the header. In addition to the app (which
 #: is the #: sender), it is passed `user`, which is the user being reloaded.
-user_loaded_from_header = _signals.signal("loaded-from-header")
+_user_loaded_from_header = _signals.signal("loaded-from-header")
 
 #: Sent when the user is loaded from the request. In addition to the app (which
 #: is the #: sender), it is passed `user`, which is the user being reloaded.
@@ -43,3 +43,19 @@ user_accessed = _signals.signal("accessed")
 #: marked non-fresh or deleted. It receives no additional arguments besides
 #: the app.
 session_protected = _signals.signal("session-protected")
+
+
+def __getattr__(name):
+    if name == "user_loaded_from_header":
+        import warnings
+
+        warnings.warn(
+            "'user_loaded_from_header' is deprecated and will be"
+            " removed in Flask-Login 0.7. Use"
+            " 'user_loaded_from_request' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _user_loaded_from_header
+
+    raise AttributeError(name)


### PR DESCRIPTION
Ensure deprecation warnings are present for deprecated features that will be removed in the 0.7 feature release.

- Use `request_loader` instead of `header_loader`.
- Use `user_loaded_from_request` instead of `user_loaded_from_header`.
- Use `app.config["LOGIN_DISABLED"]` instead of `_login_disabled`.
- Use `init_app` instead of `setup_app`.