### PR TITLE
REMEMBER_COOKIE_DURATION  shouldn't throw error when value is in string

### DIFF
--- a/src/flask_login/login_manager.py
+++ b/src/flask_login/login_manager.py
@@ -423,8 +423,8 @@ class LoginManager:
         # prepare data
         data = encode_cookie(str(session["_user_id"]))
 
-        if isinstance(duration, int):
-            duration = timedelta(seconds=duration)
+        if isinstance(duration, int) or isinstance(duration, str):
+            duration = timedelta(seconds=int(duration))
 
         try:
             expires = datetime.utcnow() + duration


### PR DESCRIPTION
Each project could have different ways to initialize Envars so values could be parsed as strings instead of integers. 

### Bug/Issue: 
<img width="1102" alt="Screen Shot 2022-10-22 at 10 50 20 AM" src="https://user-images.githubusercontent.com/87696933/197320831-ffd1afb6-d00d-4be9-bc7a-cc7c4662e896.png">

### Expected behavior: 
Fix: REMEMBER_COOKIE_DURATION  shouldn't throw an error when the value is in the string.

## Fixed: 
The issue has been fixed within this PR.
