### PR TITLE
Revised the "login_required" decorator, checking if the account is diabled, and logging out the user if if the user should not access the system

### DIFF
--- a/src/flask_login/utils.py
+++ b/src/flask_login/utils.py
@@ -281,7 +281,9 @@ def login_required(func):
     def decorated_view(*args, **kwargs):
         if request.method in EXEMPT_METHODS or current_app.config.get("LOGIN_DISABLED"):
             pass
-        elif not current_user.is_authenticated:
+        elif not current_user.is_authenticated or not current_user.is_active:
+            if not current_user.is_anonymous:
+                logout_user()
             return current_app.login_manager.unauthorized()
 
         # flask 1.x compatibility


### PR DESCRIPTION
The "login_required" decorator does not check if the user is disabled.  It won't block the user after she has logged in.
It also does not log out the user.  If an account is re-enabled, the user does not need to log in again to access the system.

Check the attached pytest test script.
[test_flask_login.zip](https://github.com/maxcountryman/flask-login/files/10327527/test_flask_login.zip)
