### PR TITLE
Update Docs to Reference a Non-Vulnerable alternative to `is_safe_url`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -136,9 +136,10 @@ function.
             flask.flash('Logged in successfully.')
 
             next = flask.request.args.get('next')
-            # is_safe_url should check if the url is safe for redirects.
-            # See http://flask.pocoo.org/snippets/62/ for an example.
-            if not is_safe_url(next):
+            # url_has_allowed_host_and_scheme should check if the url is safe
+            # for redirects, meaning it matches the request host.
+            # See Django's url_has_allowed_host_and_scheme for an example.
+            if not url_has_allowed_host_and_scheme(next, request.host):
                 return flask.abort(400)
 
             return flask.redirect(next or flask.url_for('index'))
@@ -146,7 +147,7 @@ function.
 
 *Warning:* You MUST validate the value of the `next` parameter. If you do not,
 your application will be vulnerable to open redirects. For an example
-implementation of `is_safe_url` see `this Flask Snippet`_.
+implementation of `url_has_allowed_host_and_scheme`, see Django's `Implementation <https://github.com/django/django/blob/4.0/django/utils/http.py#L239>`_.
 
 It's that simple. You can then access the logged-in user with the
 `current_user` proxy, which is available in every template::


### PR DESCRIPTION
The `flask-login` docs point to a non-existent / deprecated snippet for the implementation of the `is_safe_url` function. There are a few points worth mentioning here:

* The link is broken 😢 
* The implementation referenced has a weakness / vulnerability (details below the fold)
*  The naming of `is_safe_url` isn't as descriptive as it could be on what the function is actually doing -- suggest following Django's lead here and moving to `url_has_allowed_host_and_scheme`

This PR updates the docs to point to a non-broken link. The implementation it points to is also more robust from a security standpoint.

---

The existing snippet `is_safe_url` implementation is:

```python
from urllib.parse import urlparse, urljoin

def is_safe_url(target):
    ref_url = urlparse(request.host_url)
    test_url = urlparse(urljoin(request.host_url, target))
    return test_url.scheme in ('http', 'https') and \
           ref_url.netloc == test_url.netloc
```

The problem here is that Chrome (and IE) treat `/\` as a protocol-relative URI prefix, so something like `Location: /\example.com` is treated as a redirect to `http://example.com`, rather than as a normal relative URI and redirecting to `[current_host]/example.com`. The linked Django `url_has_allowed_host_and_scheme` implementation accounts for this potential issue.

For more details, see <https://bugs.chromium.org/p/chromium/issues/detail?id=500610> and <https://nvd.nist.gov/vuln/detail/CVE-2015-2317>