### PR TITLE
Revised the LoginTestCase to work with Werkzeug 2.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,6 @@ setup(
     name="Flask-Login",
     install_requires=[
         "Flask>=1.0.4",
-        "Werkzeug>=1.0.1",
+        "Werkzeug>=2.3.0",
     ],
 )

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -669,24 +669,16 @@ class LoginTestCase(unittest.TestCase):
         name = self.app.config["REMEMBER_COOKIE_NAME"] = "myname"
         duration = self.app.config["REMEMBER_COOKIE_DURATION"] = timedelta(days=2)
         path = self.app.config["REMEMBER_COOKIE_PATH"] = "/mypath"
-        domain = self.app.config["REMEMBER_COOKIE_DOMAIN"] = ".localhost.local"
+        domain = self.app.config["REMEMBER_COOKIE_DOMAIN"] = "localhost.local"
 
         with self.app.test_client() as c:
             c.get("/login-notch-remember")
 
-            # TODO: Is there a better way to test this?
-            self.assertIn(
-                domain,
-                c.cookie_jar._cookies,
-                "Custom domain not found as cookie domain",
-            )
-            domain_cookie = c.cookie_jar._cookies[domain]
-            self.assertIn(path, domain_cookie, "Custom path not found as cookie path")
-            path_cookie = domain_cookie[path]
-            self.assertIn(name, path_cookie, "Custom name not found as cookie name")
-            cookie = path_cookie[name]
+            cookie = c.get_cookie(key=name, domain=domain, path=path)
+            self.assertIsNotNone(cookie,
+                                 "Custom domain, path and name not found in cookies")
 
-            expiration_date = datetime.utcfromtimestamp(cookie.expires)
+            expiration_date = datetime.utcfromtimestamp(cookie.expires.timestamp())
             expected_date = datetime.utcnow() + duration
             difference = expected_date - expiration_date
 
@@ -702,24 +694,16 @@ class LoginTestCase(unittest.TestCase):
         self.app.config["REMEMBER_COOKIE_DURATION"] = 172800
         duration = timedelta(hours=7)
         path = self.app.config["REMEMBER_COOKIE_PATH"] = "/mypath"
-        domain = self.app.config["REMEMBER_COOKIE_DOMAIN"] = ".localhost.local"
+        domain = self.app.config["REMEMBER_COOKIE_DOMAIN"] = "localhost.local"
 
         with self.app.test_client() as c:
             c.get("/login-notch-remember-custom")
 
-            # TODO: Is there a better way to test this?
-            self.assertIn(
-                domain,
-                c.cookie_jar._cookies,
-                "Custom domain not found as cookie domain",
-            )
-            domain_cookie = c.cookie_jar._cookies[domain]
-            self.assertIn(path, domain_cookie, "Custom path not found as cookie path")
-            path_cookie = domain_cookie[path]
-            self.assertIn(name, path_cookie, "Custom name not found as cookie name")
-            cookie = path_cookie[name]
+            cookie = c.get_cookie(key=name, domain=domain, path=path)
+            self.assertIsNotNone(cookie,
+                                 "Custom domain, path and name not found in cookies")
 
-            expiration_date = datetime.utcfromtimestamp(cookie.expires)
+            expiration_date = datetime.utcfromtimestamp(cookie.expires.timestamp())
             expected_date = datetime.utcnow() + duration
             difference = expected_date - expiration_date
 
@@ -734,15 +718,15 @@ class LoginTestCase(unittest.TestCase):
         self.app.config["REMEMBER_COOKIE_DURATION"] = 172800
         duration = timedelta(seconds=172800)
         name = self.app.config["REMEMBER_COOKIE_NAME"] = "myname"
-        domain = self.app.config["REMEMBER_COOKIE_DOMAIN"] = ".localhost.local"
+        domain = self.app.config["REMEMBER_COOKIE_DOMAIN"] = "localhost.local"
 
         with self.app.test_client() as c:
             result = c.get("/login-notch-remember")
             self.assertEqual(result.status_code, 200)
 
-            cookie = c.cookie_jar._cookies[domain]["/"][name]
+            cookie = c.get_cookie(key=name, domain=domain, path="/")
 
-            expiration_date = datetime.utcfromtimestamp(cookie.expires)
+            expiration_date = datetime.utcfromtimestamp(cookie.expires.timestamp())
             expected_date = datetime.utcnow() + duration
             difference = expected_date - expiration_date
 
@@ -794,25 +778,23 @@ class LoginTestCase(unittest.TestCase):
         self.assertIn(expected_exception_message, str(cm.exception))
 
     def test_remember_me_refresh_every_request(self):
-        domain = self.app.config["REMEMBER_COOKIE_DOMAIN"] = ".localhost.local"
+        domain = self.app.config["REMEMBER_COOKIE_DOMAIN"] = "localhost.local"
         path = self.app.config["REMEMBER_COOKIE_PATH"] = "/"
 
         # No refresh
         self.app.config["REMEMBER_COOKIE_REFRESH_EACH_REQUEST"] = False
         with self.app.test_client() as c:
             c.get("/login-notch-remember")
-            self.assertIn("remember", c.cookie_jar._cookies[domain][path])
-            expiration_date_1 = datetime.utcfromtimestamp(
-                c.cookie_jar._cookies[domain][path]["remember"].expires
-            )
+            cookie = c.get_cookie(key="remember", domain=domain, path=path)
+            self.assertIsNotNone(cookie)
+            expiration_date_1 = datetime.utcfromtimestamp(cookie.expires.timestamp())
 
             self._delete_session(c)
 
             c.get("/username")
-            self.assertIn("remember", c.cookie_jar._cookies[domain][path])
-            expiration_date_2 = datetime.utcfromtimestamp(
-                c.cookie_jar._cookies[domain][path]["remember"].expires
-            )
+            cookie = c.get_cookie(key="remember", domain=domain, path=path)
+            self.assertIsNotNone(cookie)
+            expiration_date_2 = datetime.utcfromtimestamp(cookie.expires.timestamp())
             self.assertEqual(expiration_date_1, expiration_date_2)
 
         # With refresh (mock datetime's `utcnow`)
@@ -823,19 +805,19 @@ class LoginTestCase(unittest.TestCase):
 
             with self.app.test_client() as c:
                 c.get("/login-notch-remember")
-                self.assertIn("remember", c.cookie_jar._cookies[domain][path])
+                cookie = c.get_cookie(key="remember", domain=domain, path=path)
                 expiration_date_1 = datetime.utcfromtimestamp(
-                    c.cookie_jar._cookies[domain][path]["remember"].expires
+                    cookie.expires.timestamp()
                 )
                 self.assertIsNotNone(expiration_date_1)
 
                 self._delete_session(c)
 
                 mock_dt.utcnow = Mock(return_value=now + timedelta(seconds=1))
-                c.get("/username")
-                self.assertIn("remember", c.cookie_jar._cookies[domain][path])
+                c.get("/login-notch-remember")
+                cookie = c.get_cookie(key="remember", domain=domain, path=path)
                 expiration_date_2 = datetime.utcfromtimestamp(
-                    c.cookie_jar._cookies[domain][path]["remember"].expires
+                    cookie.expires.timestamp()
                 )
                 self.assertIsNotNone(expiration_date_2)
                 self.assertNotEqual(expiration_date_1, expiration_date_2)


### PR DESCRIPTION
The cookie_jar property is deprecated in Werkzeug 2.3 and will be removed in Werkzeug 2.4.  The current LoginTestCase does not work with Werkzeug 2.3.  Revised the test case to work with Werkzeug 2.3 and above.