### PR TITLE
Add post login handler

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -257,6 +257,25 @@ using the `Authorization` header::
         # finally, return None if both methods did not login the user
         return None
 
+Custom Post Login Callback
+==========================
+Sometimes, when a user is logged in, you want to execute some functions or
+processes like storing the last logged in time. In these cases, you should
+use the `~LoginManager.post_login_handler` callback. This callback accepts
+a user object and returns None.
+
+This gets executed even if the user was loaded from remeber me cookie, session
+or request.
+
+For example, to add the user id to a file after login::
+
+    from datetime import datetime
+
+    @login_manager.post_login_handler
+    def pos_login_callback(user):
+        current_datetime = datetime.now()
+        with open("login_logs.txt", "a") as logs:
+            logs.write(f"{user.id} logged in at {current_datetime}\n")
 
 Anonymous Users
 ===============

--- a/src/flask_login/login_manager.py
+++ b/src/flask_login/login_manager.py
@@ -93,6 +93,9 @@ class LoginManager:
 
         self.id_attribute = ID_ATTRIBUTE
 
+        #: If present, executed in ``self._load_user``
+        self._post_login_callback = None
+
         self._user_callback = None
 
         self._request_callback = None
@@ -211,6 +214,17 @@ class LoginManager:
     def request_callback(self):
         """Gets the request_loader callback set by request_loader decorator."""
         return self._request_callback
+
+    def post_login_handler(self, callback):
+        """
+        This sets the callback for executing procs after login. The
+        function you set should take a user object and return ``None``.
+
+        :param callback: The callback for executing processes after login.
+        :type callback: callable
+        """
+        self._post_login_callback = callback
+        return self._post_login_callback
 
     def unauthorized_handler(self, callback):
         """
@@ -333,6 +347,10 @@ class LoginManager:
                 user = self._load_user_from_remember_cookie(cookie)
             elif self._request_callback:
                 user = self._load_user_from_request(request)
+
+        # Execute post login callback
+        if self._post_login_callback:
+            self._post_login_callback(user)
 
         return self._update_request_context_with_user(user)
 

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -136,6 +136,7 @@ creeper = User("Creeper", 3, False)
 germanjapanese = User("Müller", "佐藤")  # str user_id
 
 USERS = {1: notch, 2: steve, 3: creeper, "佐藤": germanjapanese}
+TEST_USER_ID = None  # For post login callback test
 
 
 class AboutTestCase(unittest.TestCase):
@@ -314,6 +315,12 @@ class LoginTestCase(unittest.TestCase):
         @self.login_manager.user_loader
         def load_user(user_id):
             return USERS[int(user_id)]
+
+        @self.login_manager.post_login_handler
+        def post_login_callback(user):
+            if user:
+                global TEST_USER_ID
+                TEST_USER_ID = user.id
 
         @self.login_manager.request_loader
         def load_user_from_request(request):
@@ -1273,6 +1280,11 @@ class LoginTestCase(unittest.TestCase):
         with self.app.test_request_context():
             _ucp = self.app.context_processor(_user_context_processor)
             self.assertIsInstance(_ucp()["current_user"], AnonymousUserMixin)
+
+    def test_post_login_handler(self):
+        with self.app.test_request_context():
+            login_user(notch)
+            self.assertEqual(notch.id, TEST_USER_ID)
 
 
 class LoginViaRequestTestCase(unittest.TestCase):


### PR DESCRIPTION
Added an option for a new callback named post_login_callback. This gets executed at the end of the _load_user function and serves the utility of executing any processes after logging in. 
For example, when we are using remember me functionality from Flask login, and we have to log the user login times to a database, we can use this callback to do so.
Another use case can be sending a login notification.

Please review and share feedback on the proposed change.
Thank You