### PR TITLE
Limit Werkzeug version to <3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,6 @@ setup(
     name="Flask-Login",
     install_requires=[
         "Flask>=1.0.4",
-        "Werkzeug>=1.0.1",
+        "Werkzeug>=1.0.1,<3.0.0",
     ],
 )


### PR DESCRIPTION
As 3.0.0 removes deprecated methods that Flask-Login currently uses.

This is intended as an interim measure to avoid breaking consumers until https://github.com/maxcountryman/flask-login/issues/744 is completed.

Some tests are failing, but I believe those tests are all the login tests that https://github.com/maxcountryman/flask-login/pull/743 fixes, and that can be seen to already have been broken from https://github.com/maxcountryman/flask-login/actions/runs/6267010322/job/17019186177.