### PR TITLE
Flask 3.x/Werkzeug 3.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Version 0.8.0
 
 Unreleased
 
+- Support for Flask 3.x and Werkzeug 3.0.0+
+
+Version 0.7.0
+-------------
+
+Unreleased
+
 - Remove previously deprecated code. #694
 
 Version 0.6.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Flask-Login Changelog
 =====================
 
-Version 0.7.0
+Version 0.8.0
 -------------
 
 Unreleased

--- a/requirements/ci-release.txt
+++ b/requirements/ci-release.txt
@@ -7,7 +7,7 @@
 #
 bleach==4.1.0
     # via readme-renderer
-build==0.7.0
+build==0.8.0
     # via -r ci-release.in
 certifi==2022.12.7
     # via requests

--- a/src/flask_login/utils.py
+++ b/src/flask_login/utils.py
@@ -11,8 +11,8 @@ from flask import request
 from flask import session
 from flask import url_for
 from werkzeug.local import LocalProxy
-from werkzeug.urls import url_decode
-from werkzeug.urls import url_encode
+from urllib.parse import unquote
+from urllib.parse import urlencode
 
 from .config import COOKIE_NAME
 from .config import EXEMPT_METHODS
@@ -123,11 +123,11 @@ def login_url(login_view, next_url=None, next_field="next"):
         return base
 
     parsed_result = urlparse(base)
-    md = url_decode(parsed_result.query)
+    md = unquote(parsed_result.query)
     md[next_field] = make_next_param(base, next_url)
     netloc = current_app.config.get("FORCE_HOST_FOR_REDIRECTS") or parsed_result.netloc
     parsed_result = parsed_result._replace(
-        netloc=netloc, query=url_encode(md, sort=True)
+        netloc=netloc, query=urlencode(md, sort=True)
     )
     return urlunparse(parsed_result)
 


### PR DESCRIPTION
Replaced url_decode and url_encode from werkzeug.urls with their direct replacements from urllib