### PR TITLE
Flask and Werkzeug 3 compat, release 0.6.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,32 +2,32 @@ ci:
   autoupdate_schedule: monthly
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v3.15.0
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.0.1
+    rev: v3.12.0
     hooks:
       - id: reorder-python-imports
         additional_dependencies: ["setuptools>60.9"]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.10.1
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.1.0
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-bugbear
           - flake8-implicit-str-concat
   - repo: https://github.com/peterdemin/pip-compile-multi
-    rev: v2.4.3
+    rev: v2.6.3
     hooks:
       - id: pip-compile-multi-verify
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.5.0
     hooks:
       - id: fix-byte-order-marker
       - id: trailing-whitespace

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Flask-Login Changelog
 Version 0.6.3
 -------------
 
-Unreleased
+Released 2023-10-30
 
 -   Compatibility with Flask 3 and Werkzeug 3. #813
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 Flask-Login Changelog
 =====================
 
+
+Version 0.6.3
+-------------
+
+Unreleased
+
+
 Version 0.6.2
 -------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Version 0.6.3
 
 Unreleased
 
+-   Compatibility with Flask 3 and Werkzeug 3. #813
+
 
 Version 0.6.2
 -------------

--- a/requirements/ci-release.txt
+++ b/requirements/ci-release.txt
@@ -5,77 +5,61 @@
 #
 #    pip-compile-multi
 #
-bleach==4.1.0
-    # via readme-renderer
-build==0.7.0
+build==1.0.3
     # via -r requirements/ci-release.in
-certifi==2021.10.8
+certifi==2023.7.22
     # via requests
-cffi==1.15.0
-    # via cryptography
-charset-normalizer==2.0.12
+charset-normalizer==3.3.1
     # via requests
-colorama==0.4.4
-    # via twine
-cryptography==36.0.2
-    # via secretstorage
-docutils==0.18.1
+docutils==0.20.1
     # via readme-renderer
-idna==3.3
+idna==3.4
     # via requests
-importlib-metadata==4.11.3
+importlib-metadata==6.8.0
     # via
     #   keyring
     #   twine
-jeepney==0.7.1
-    # via
-    #   keyring
-    #   secretstorage
-keyring==23.5.0
+jaraco-classes==3.3.0
+    # via keyring
+keyring==24.2.0
     # via twine
-packaging==21.3
-    # via
-    #   bleach
-    #   build
-pep517==0.12.0
-    # via build
-pkginfo==1.8.2
-    # via twine
-pycparser==2.21
-    # via cffi
-pygments==2.11.2
+markdown-it-py==3.0.0
+    # via rich
+mdurl==0.1.2
+    # via markdown-it-py
+more-itertools==10.1.0
+    # via jaraco-classes
+nh3==0.2.14
     # via readme-renderer
-pyparsing==3.0.7
-    # via packaging
-readme-renderer==34.0
+packaging==23.2
+    # via build
+pkginfo==1.9.6
+    # via twine
+pygments==2.16.1
+    # via
+    #   readme-renderer
+    #   rich
+pyproject-hooks==1.0.0
+    # via build
+readme-renderer==42.0
     # via
     #   -r requirements/ci-release.in
     #   twine
-requests==2.27.1
+requests==2.31.0
     # via
     #   requests-toolbelt
     #   twine
-requests-toolbelt==0.9.1
+requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-secretstorage==3.3.1
-    # via keyring
-six==1.16.0
-    # via bleach
-tomli==2.0.1
-    # via
-    #   build
-    #   pep517
-tqdm==4.63.1
+rich==13.6.0
     # via twine
-twine==3.8.0
+twine==4.0.2
     # via -r requirements/ci-release.in
-urllib3==1.26.9
+urllib3==2.0.7
     # via
     #   requests
     #   twine
-webencodings==0.5.1
-    # via bleach
-zipp==3.7.0
+zipp==3.17.0
     # via importlib-metadata

--- a/requirements/ci-tests.txt
+++ b/requirements/ci-tests.txt
@@ -5,45 +5,47 @@
 #
 #    pip-compile-multi
 #
-certifi==2021.10.8
+cachetools==5.3.2
+    # via tox
+certifi==2023.7.22
     # via requests
-charset-normalizer==2.0.12
+chardet==5.2.0
+    # via tox
+charset-normalizer==3.3.1
     # via requests
-coverage==6.3.2
+colorama==0.4.6
+    # via tox
+coverage==6.5.0
     # via coveralls
 coveralls==3.3.1
     # via -r requirements/ci-tests.in
-distlib==0.3.4
+distlib==0.3.7
     # via virtualenv
 docopt==0.6.2
     # via coveralls
-filelock==3.6.0
+filelock==3.13.0
     # via
     #   tox
     #   virtualenv
-idna==3.3
+idna==3.4
     # via requests
-packaging==21.3
+packaging==23.2
+    # via
+    #   pyproject-api
+    #   tox
+platformdirs==3.11.0
+    # via
+    #   tox
+    #   virtualenv
+pluggy==1.3.0
     # via tox
-platformdirs==2.5.1
-    # via virtualenv
-pluggy==1.0.0
+pyproject-api==1.6.1
     # via tox
-py==1.11.0
-    # via tox
-pyparsing==3.0.7
-    # via packaging
-requests==2.27.1
+requests==2.31.0
     # via coveralls
-six==1.16.0
-    # via
-    #   tox
-    #   virtualenv
-toml==0.10.2
-    # via tox
-tox==3.24.5
+tox==4.11.3
     # via -r requirements/ci-tests.in
-urllib3==1.26.9
+urllib3==2.0.7
     # via requests
-virtualenv==20.14.0
+virtualenv==20.24.6
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,21 +8,31 @@
 -r docs.txt
 -r style.txt
 -r tests.txt
-click==8.1.0
+build==1.0.3
+    # via pip-tools
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+click==8.1.7
     # via
     #   pip-compile-multi
     #   pip-tools
-pep517==0.12.0
-    # via pip-tools
-pip-compile-multi==2.4.3
+colorama==0.4.6
+    # via tox
+pip-compile-multi==2.6.3
     # via -r requirements/dev.in
-pip-tools==6.5.1
+pip-tools==7.3.0
     # via pip-compile-multi
-toposort==1.7
+pyproject-api==1.6.1
+    # via tox
+pyproject-hooks==1.0.0
+    # via build
+toposort==1.10
     # via pip-compile-multi
-tox==3.24.5
+tox==4.11.3
     # via -r requirements/dev.in
-wheel==0.37.1
+wheel==0.41.2
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,49 +5,51 @@
 #
 #    pip-compile-multi
 #
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
-babel==2.9.1
+babel==2.13.1
     # via sphinx
-certifi==2021.10.8
+certifi==2023.7.22
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==3.3.1
     # via requests
-docutils==0.17.1
+docutils==0.20.1
     # via sphinx
-idna==3.3
+idna==3.4
     # via requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
-jinja2==3.1.1
+jinja2==3.1.2
     # via sphinx
-markupsafe==2.1.1
+markupsafe==2.1.3
     # via jinja2
-packaging==21.3
+packaging==23.2
     # via sphinx
-pygments==2.11.2
+pygments==2.16.1
     # via sphinx
-pyparsing==3.0.7
-    # via packaging
-pytz==2022.1
-    # via babel
-requests==2.27.1
+requests==2.31.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.5.0
-    # via -r requirements/docs.in
-sphinxcontrib-applehelp==1.0.2
+sphinx==7.2.6
+    # via
+    #   -r requirements/docs.in
+    #   sphinxcontrib-applehelp
+    #   sphinxcontrib-devhelp
+    #   sphinxcontrib-htmlhelp
+    #   sphinxcontrib-qthelp
+    #   sphinxcontrib-serializinghtml
+sphinxcontrib-applehelp==1.0.7
     # via sphinx
-sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-devhelp==1.0.5
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.4
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-qthelp==1.0.6
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
-urllib3==1.26.9
+urllib3==2.0.7
     # via requests

--- a/requirements/style.txt
+++ b/requirements/style.txt
@@ -5,25 +5,24 @@
 #
 #    pip-compile-multi
 #
-cfgv==3.3.1
+cfgv==3.4.0
     # via pre-commit
-distlib==0.3.4
+distlib==0.3.7
     # via virtualenv
-filelock==3.6.0
+filelock==3.13.0
     # via virtualenv
-identify==2.4.12
+identify==2.5.31
     # via pre-commit
-nodeenv==1.6.0
+nodeenv==1.8.0
     # via pre-commit
-platformdirs==2.5.1
+platformdirs==3.11.0
     # via virtualenv
-pre-commit==2.17.0
+pre-commit==3.5.0
     # via -r requirements/style.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via pre-commit
-six==1.16.0
-    # via virtualenv
-toml==0.10.2
+virtualenv==20.24.6
     # via pre-commit
-virtualenv==20.14.0
-    # via pre-commit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,27 +5,19 @@
 #
 #    pip-compile-multi
 #
-asgiref==3.5.0
+asgiref==3.7.2
     # via -r requirements/tests.in
-attrs==21.4.0
-    # via pytest
-blinker==1.4
+blinker==1.6.3
     # via -r requirements/tests.in
-coverage==6.3.2
+coverage==7.3.2
     # via -r requirements/tests.in
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
-packaging==21.3
+packaging==23.2
     # via pytest
-pluggy==1.0.0
+pluggy==1.3.0
     # via pytest
-py==1.11.0
-    # via pytest
-pyparsing==3.0.7
-    # via packaging
-pytest==7.1.1
+pytest==7.4.3
     # via -r requirements/tests.in
-semantic-version==2.9.0
+semantic-version==2.10.0
     # via -r requirements/tests.in
-tomli==2.0.1
-    # via pytest

--- a/src/flask_login/__about__.py
+++ b/src/flask_login/__about__.py
@@ -1,7 +1,7 @@
 __title__ = "Flask-Login"
 __description__ = "User session management for Flask"
 __url__ = "https://github.com/maxcountryman/flask-login"
-__version_info__ = ("0", "6", "2")
+__version_info__ = ("0", "6", "3")
 __version__ = ".".join(__version_info__)
 __author__ = "Matthew Frazier"
 __author_email__ = "leafstormrush@gmail.com"

--- a/src/flask_login/utils.py
+++ b/src/flask_login/utils.py
@@ -349,14 +349,12 @@ def set_login_view(login_view, blueprint=None):
 
     num_login_views = len(current_app.login_manager.blueprint_login_views)
     if blueprint is not None or num_login_views != 0:
-
         (current_app.login_manager.blueprint_login_views[blueprint.name]) = login_view
 
         if (
             current_app.login_manager.login_view is not None
             and None not in current_app.login_manager.blueprint_login_views
         ):
-
             (
                 current_app.login_manager.blueprint_login_views[None]
             ) = current_app.login_manager.login_view

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -528,7 +528,6 @@ class LoginTestCase(unittest.TestCase):
 
     def test_unauthorized_uses_blueprint_login_view(self):
         with self.app.app_context():
-
             first = Blueprint("first", "first")
             second = Blueprint("second", "second")
 
@@ -567,7 +566,6 @@ class LoginTestCase(unittest.TestCase):
             set_login_view("second_login", blueprint=second)
 
             with self.app.test_client() as c:
-
                 result = c.get("/protected")
                 self.assertEqual(result.status_code, 302)
                 expected = "/app_login?next=%2Fprotected"
@@ -598,7 +596,6 @@ class LoginTestCase(unittest.TestCase):
             set_login_view("app_login")
 
             with self.app.test_client() as c:
-
                 result = c.get("/protected")
                 self.assertEqual(result.status_code, 302)
                 expected = "/app_login?next=%2Fprotected"


### PR DESCRIPTION
This branches off the 0.6.2 tag, and redoes the compatibility fixes. The previous fixes were merged into main, which already had some changes for 0.7, while 0.6.3 should only be about fixes. The fixes are also a bit different than the previous PRs.

The Werkzeug test client's cookie methods changed, and the tests now pass with both Werkzeug<2.3 and latest. 0.7 will drop this Werkzeug<2.3 compat later.

Werkzeug 3 no longer has an outdated copy of urllib, so we import directly from Python's built-in `urllib.parse` instead. The more modern `urlsplit` is used instead of `urlparse` as well.

This will not merge cleanly into main through GitHub, so I will merge it manually. That may be why the CI tests didn't run here, but they do pass locally. I will start the release process tomorrow.