### PR TITLE
use `datetime.now` with timezone instead of `utcnow`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Unreleased
 - Bump to Flask >= 2.3.0.
 - Bump to Werkzeug >= 2.3.2.
 - Remove previously deprecated code. #694
+- Use `datetime.now(timezone.utc)` instead of deprecated `datetime.utcnow`. #758
 
 
 Version 0.6.3

--- a/src/flask_login/login_manager.py
+++ b/src/flask_login/login_manager.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
 from flask import abort
 from flask import current_app
@@ -427,7 +428,7 @@ class LoginManager:
             duration = timedelta(seconds=duration)
 
         try:
-            expires = datetime.utcnow() + duration
+            expires = datetime.now(timezone.utc) + duration
         except TypeError as e:
             raise Exception(
                 "REMEMBER_COOKIE_DURATION must be a datetime.timedelta,"

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -765,8 +765,8 @@ class LoginTestCase(unittest.TestCase):
 
     def test_remember_me_refresh_each_request(self):
         with patch("flask_login.login_manager.datetime") as mock_dt:
-            now = datetime.utcnow()
-            mock_dt.utcnow = Mock(return_value=now)
+            now = datetime.now(timezone.utc)
+            mock_dt.now = Mock(return_value=now)
 
             domain = self.app.config["REMEMBER_COOKIE_DOMAIN"] = "localhost.local"
             path = self.app.config["REMEMBER_COOKIE_PATH"] = "/"
@@ -775,7 +775,7 @@ class LoginTestCase(unittest.TestCase):
             c.get("/login-notch-remember")
             cookie1 = c.get_cookie("remember", domain, path)
             self.assertIsNotNone(cookie1.expires)
-            mock_dt.utcnow.return_value = now + timedelta(seconds=1)
+            mock_dt.now.return_value = now + timedelta(seconds=1)
             c.get("/username")
             cookie2 = c.get_cookie("remember", domain, path)
             self.assertNotEqual(cookie1.expires, cookie2.expires)


### PR DESCRIPTION
`datetime.utcnow`, which returns a naive datetime, is deprecated in favor of `datetime.now(timezone.utc)`, which returns an aware datetime with the UTC timezone. Werkzeug and Flask already updated to use aware datetimes in their headers and other values.

Already addressed many of the tests using `utcnow` in #813. This fixes the one use in the source, and the tests that referenced it.

fixes #758 