### PR TITLE
Replace expires cookie attribute with max-age attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Unreleased
 - Use `datetime.now(timezone.utc)` instead of deprecated `datetime.utcnow`. #758
 - Never look at the `X-Forwarded-For` header, always use `request.remote_addr`,
   requiring the developer to configure `ProxyFix` appropriately. #700
+- Replace `expires` attribute with `max-age` in "remember_me" cookie. #823
 
 
 Version 0.6.3

--- a/src/flask_login/login_manager.py
+++ b/src/flask_login/login_manager.py
@@ -1,7 +1,3 @@
-from datetime import datetime
-from datetime import timedelta
-from datetime import timezone
-
 from flask import abort
 from flask import current_app
 from flask import flash
@@ -417,29 +413,19 @@ class LoginManager:
         samesite = config.get("REMEMBER_COOKIE_SAMESITE", COOKIE_SAMESITE)
 
         if "_remember_seconds" in session:
-            duration = timedelta(seconds=session["_remember_seconds"])
+            # Convert float to int
+            duration = int(session["_remember_seconds"])
         else:
             duration = config.get("REMEMBER_COOKIE_DURATION", COOKIE_DURATION)
 
         # prepare data
         data = encode_cookie(str(session["_user_id"]))
 
-        if isinstance(duration, int):
-            duration = timedelta(seconds=duration)
-
-        try:
-            expires = datetime.now(timezone.utc) + duration
-        except TypeError as e:
-            raise Exception(
-                "REMEMBER_COOKIE_DURATION must be a datetime.timedelta,"
-                f" instead got: {duration}"
-            ) from e
-
         # actually set it
         response.set_cookie(
             cookie_name,
             value=data,
-            expires=expires,
+            max_age=duration,
             domain=domain,
             path=path,
             secure=secure,

--- a/src/flask_login/utils.py
+++ b/src/flask_login/utils.py
@@ -189,11 +189,7 @@ def login_user(user, remember=False, duration=None, force=False, fresh=True):
         session["_remember"] = "set"
         if duration is not None:
             try:
-                # equal to timedelta.total_seconds() but works with Python 2.6
-                session["_remember_seconds"] = (
-                    duration.microseconds
-                    + (duration.seconds + duration.days * 24 * 3600) * 10**6
-                ) / 10.0**6
+                session["_remember_seconds"] = duration.total_seconds()
             except AttributeError as e:
                 raise Exception(
                     f"duration must be a datetime.timedelta, instead got: {duration}"


### PR DESCRIPTION
~Internet Explorer doesn't support max-age cookie attribute. I don't know any other reason to use expires instead of max-age.~ I was checking wrong "max-age". Even Internet Explorer supports max-age since IE 9 [(source)](https://caniuse.com/mdn-http_headers_set-cookie_max-age)

Max-age works even if client or server clocks have wrong time.