### PR TITLE
fixed cookie refresh bug

### DIFF
--- a/src/flask_login/login_manager.py
+++ b/src/flask_login/login_manager.py
@@ -402,6 +402,8 @@ class LoginManager:
                 self._set_cookie(response)
             elif operation == "clear":
                 self._clear_cookie(response)
+            elif operation == "unset":
+                session["_remember"] = "unset"
 
         return response
 

--- a/src/flask_login/utils.py
+++ b/src/flask_login/utils.py
@@ -198,6 +198,8 @@ def login_user(user, remember=False, duration=None, force=False, fresh=True):
                 raise Exception(
                     f"duration must be a datetime.timedelta, instead got: {duration}"
                 ) from e
+    else:
+        session["_remember"] = "unset"
 
     current_app.login_manager._update_request_context_with_user(user)
     user_logged_in.send(current_app._get_current_object(), user=_get_user())

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1758,3 +1758,4 @@ class CookieRefreshTest(unittest.TestCase):
             cookie = c.get_cookie(name, domain, path)
 
             self.assertIsNone(cookie)
+

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1665,10 +1665,11 @@ class CustomTestClientTestCase(unittest.TestCase):
 class CookieRefreshTest(unittest.TestCase):
     """
     This class tests the bug from issue #824. It makes sure that if a user is
-    logged in with their "rememeber" parameter as False, that user doesn't 
-    have any cookies, even if the "REMEMBER_COOKIE_REFRESH_EACH_REQUEST" 
+    logged in with their "rememeber" parameter as False, that user doesn't
+    have any cookies, even if the "REMEMBER_COOKIE_REFRESH_EACH_REQUEST"
     config option is True.
     """
+
     def setUp(self):
         self.app = Flask(__name__)
         self.login_manager = LoginManager()
@@ -1681,25 +1682,25 @@ class CookieRefreshTest(unittest.TestCase):
 
         @self.app.route("/login-notch0")
         def login_notch0():
-            self.app.config['REMEMBER_COOKIE_REFRESH_EACH_REQUEST'] = True
+            self.app.config["REMEMBER_COOKIE_REFRESH_EACH_REQUEST"] = True
             login_user(notch, remember=True)
             return "Hello"
 
         @self.app.route("/login-notch1")
         def login_notch1():
-            self.app.config['REMEMBER_COOKIE_REFRESH_EACH_REQUEST'] = False
+            self.app.config["REMEMBER_COOKIE_REFRESH_EACH_REQUEST"] = False
             login_user(notch, remember=True)
             return "Hello"
         
         @self.app.route("/login-notch2")
         def login_notch2():
-            self.app.config['REMEMBER_COOKIE_REFRESH_EACH_REQUEST'] = True
+            self.app.config["REMEMBER_COOKIE_REFRESH_EACH_REQUEST"] = True
             login_user(notch, remember=False)
             return "Hello"
         
         @self.app.route("/login-notch3")
         def login_notch3():
-            self.app.config['REMEMBER_COOKIE_REFRESH_EACH_REQUEST'] = False
+            self.app.config["REMEMBER_COOKIE_REFRESH_EACH_REQUEST"] = False
             login_user(notch, remember=False)
             return "Hello"
         
@@ -1713,8 +1714,8 @@ class CookieRefreshTest(unittest.TestCase):
 
         unittest.TestCase.setUp(self)
 
-    #each of these function tests one of the ways cookie rememberance
-    #configuration options can be set.
+    # each of these function tests one of the ways cookie rememberance
+    # configuration options can be set.
     def test_0(self):
         with self.app.test_client() as c:
             name = self.app.config["REMEMBER_COOKIE_NAME"] = "myname"
@@ -1725,7 +1726,7 @@ class CookieRefreshTest(unittest.TestCase):
 
             cookie = c.get_cookie(name, domain, path)
             self.assertIsNotNone(cookie)
-        
+
     def test_1(self):
         with self.app.test_client() as c:
             name = self.app.config["REMEMBER_COOKIE_NAME"] = "myname"
@@ -1736,7 +1737,7 @@ class CookieRefreshTest(unittest.TestCase):
 
             cookie = c.get_cookie(name, domain, path)
             self.assertIsNotNone(cookie)
-        
+
     def test_2(self):
         with self.app.test_client() as c:
             name = self.app.config["REMEMBER_COOKIE_NAME"] = "myname"
@@ -1747,7 +1748,7 @@ class CookieRefreshTest(unittest.TestCase):
 
             cookie = c.get_cookie(name, domain, path)
             self.assertIsNone(cookie)
-        
+
     def test_3(self):
         with self.app.test_client() as c:
             name = self.app.config["REMEMBER_COOKIE_NAME"] = "myname"
@@ -1758,4 +1759,3 @@ class CookieRefreshTest(unittest.TestCase):
             cookie = c.get_cookie(name, domain, path)
 
             self.assertIsNone(cookie)
-

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1691,19 +1691,19 @@ class CookieRefreshTest(unittest.TestCase):
             self.app.config["REMEMBER_COOKIE_REFRESH_EACH_REQUEST"] = False
             login_user(notch, remember=True)
             return "Hello"
-        
+
         @self.app.route("/login-notch2")
         def login_notch2():
             self.app.config["REMEMBER_COOKIE_REFRESH_EACH_REQUEST"] = True
             login_user(notch, remember=False)
             return "Hello"
-        
+
         @self.app.route("/login-notch3")
         def login_notch3():
             self.app.config["REMEMBER_COOKIE_REFRESH_EACH_REQUEST"] = False
             login_user(notch, remember=False)
             return "Hello"
-        
+
         # This will help us with the possibility of typos in the tests. Now
         # we shouldn't have to check each response to help us set up state
         # (such as login pages) to make sure it worked: we will always


### PR DESCRIPTION
Issue #824. Before, if a user was logged in with the login_user function when the remember parameter was set to false, their cookies would still be refreshed if the "REMEMBER_COOKIE_REFRESH_EACH_REQUEST" configuration option was set to true. This happens because if the login_user function has the remember parameter be false, it doesn't assign session["_rememeber"] any value. When session["_rememeber"] doesn't have any value and the "REMEMBER_COOKIE_REFRESH_EACH_REQUEST" configuration option is set to true, the _update_remember_cookie function sets the session["_rememeber"] value to "set". This fix makes it so if the login_user function is given false for the remember parameter, instead of leaving session["_remember"] empty, it  sets the value to "unset".