### PR TITLE
Fall back to request loader on invalid remember cookie

### DIFF
--- a/src/flask_login/login_manager.py
+++ b/src/flask_login/login_manager.py
@@ -330,7 +330,7 @@ class LoginManager:
             if has_cookie:
                 cookie = request.cookies[cookie_name]
                 user = self._load_user_from_remember_cookie(cookie)
-            elif self._request_callback:
+            if user is None and self._request_callback:
                 user = self._load_user_from_request(request)
 
         return self._update_request_context_with_user(user)


### PR DESCRIPTION
If the remember cookie is invalid, then Flask-login should act as if it doesn't exist.  Meaning, it should fall back on using the request loader to login in.

Steps to reproduce bug:
Login to webapp
Open developer tools and edit the remember_token cookie so that it becomes invalid (but still exists). Remove the session cookie.
Reload the webapp page and Login (i.e. reload it in such a way as it should login using the request loader).

Expected behavior:
Webapp should login (valid credentials were provided via POST and should be processed by the request loader).

Actual behavior:
Unauthenticated page loads, since the request loader never gets called (due to the invalid remember_token being present).  This leaves the webapp in a very bad state where login is not possible.