### PR TITLE
Use request_ctx from flask.globals rather then g from Flask for storing logged in user data

### DIFF
--- a/src/flask_login/login_manager.py
+++ b/src/flask_login/login_manager.py
@@ -5,7 +5,7 @@ from datetime import timezone
 from flask import abort
 from flask import current_app
 from flask import flash
-from flask import g
+from flask.globals import request_ctx
 from flask import redirect
 from flask import request
 from flask import session
@@ -294,10 +294,7 @@ class LoginManager:
     def _update_request_context_with_user(self, user=None):
         """Store the given user as ctx.user."""
 
-        if user is None:
-            user = self.anonymous_user()
-
-        g._login_user = user
+        request_ctx.user = self.anonymous_user() if user is None else user
 
     def _load_user(self):
         """Loads user from session or remember_me cookie as applicable"""

--- a/src/flask_login/utils.py
+++ b/src/flask_login/utils.py
@@ -7,7 +7,7 @@ from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
 
 from flask import current_app
-from flask import g
+from flask.globals import request_ctx
 from flask import has_request_context
 from flask import request
 from flask import session
@@ -358,14 +358,10 @@ def set_login_view(login_view, blueprint=None):
 
 
 def _get_user():
-    if has_request_context():
-        if "_login_user" not in g:
-            current_app.login_manager._load_user()
+    if has_request_context() and not hasattr(request_ctx, "user"):
+        current_app.login_manager._load_user()
 
-        return g._login_user
-
-    return None
-
+    return getattr(request_ctx, "user", None)
 
 def _cookie_digest(payload, key=None):
     key = _secret_key(key)


### PR DESCRIPTION
Storing the logged in user data in flask.g in a gunicorn multi-process server results in the data only being available in one of the processes and can result in other users picking up user data other than their own.  This is avoided by using flask.globals.request_ctx 